### PR TITLE
Update font-d2coding to 1.3.2,20180524

### DIFF
--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -8,5 +8,5 @@ cask 'font-d2coding' do
   name 'D2 Coding'
   homepage 'https://github.com/naver/d2codingfont'
 
-  font "D2Coding-Ver#{version.before_comma}-#{version.after_comma}/D2Coding/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.ttc"
+  font "D2Coding/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.ttc"
 end

--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -1,10 +1,10 @@
 cask 'font-d2coding' do
-  version '1.3.1,20180115'
-  sha256 '06f3fdb7a5a02e695af47ae95bd246713745e191628fd9a1bea670a67528b82c'
+  version '1.3.2,20180524'
+  sha256 '0f1c9192eac7d56329dddc620f9f1666b707e9c8ed38fe1f988d0ae3e30b24e6'
 
   url "https://github.com/naver/d2codingfont/releases/download/VER#{version.before_comma}/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://github.com/naver/d2codingfont/releases.atom',
-          checkpoint: '7624423ea790852c136928f39779d169315f5df1fb880eec077f7d4c7251ac3a'
+          checkpoint: '7aa2c30c866f286ae3223763055e8007ce2303e05be7b9440809a8cafe3c9cb0'
   name 'D2 Coding'
   homepage 'https://github.com/naver/d2codingfont'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.