### PR TITLE
Update font-fontawesome to v5.2.0

### DIFF
--- a/Casks/font-fontawesome.rb
+++ b/Casks/font-fontawesome.rb
@@ -1,14 +1,14 @@
 cask 'font-fontawesome' do
-  version '5.0.13'
-  sha256 '79f59af3a08a1356a700e23d802758fcb40dd2446bf7fe0424600afb98e07906'
+  version '5.2.0'
+  sha256 '070fc7fedbff9cf41f822bf888ba06c797faa20a3fd7805d0059003eba591216'
 
   # github.com/FortAwesome/Font-Awesome was verified as official when first introduced to the cask
-  url "https://github.com/FortAwesome/Font-Awesome/archive/#{version}.zip"
+  url "https://github.com/FortAwesome/Font-Awesome/releases/download/#{version}/fontawesome-free-#{version}-desktop.zip"
   appcast 'https://github.com/FortAwesome/Font-Awesome/releases.atom'
   name 'Font Awesome'
   homepage 'http://fontawesome.io/'
 
-  font "Font-Awesome-#{version}/use-on-desktop/Font Awesome #{version.major} Brands-Regular-400.otf"
-  font "Font-Awesome-#{version}/use-on-desktop/Font Awesome #{version.major} Free-Regular-400.otf"
-  font "Font-Awesome-#{version}/use-on-desktop/Font Awesome #{version.major} Free-Solid-900.otf"
+  font "fontawesome-free-#{version}-desktop/otfs/Font Awesome #{version.major} Brands-Regular-400.otf"
+  font "fontawesome-free-#{version}-desktop/otfs/Font Awesome #{version.major} Free-Regular-400.otf"
+  font "fontawesome-free-#{version}-desktop/otfs/Font Awesome #{version.major} Free-Solid-900.otf"
 end


### PR DESCRIPTION
Update URL to smaller file for desktop usage (reduces from 15 MB to 5 MB)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[closed issues]: https://github.com/Homebrew/homebrew-cask-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
