### PR TITLE
Update IBM Plex to v1.1.3

### DIFF
--- a/Casks/font-ibm-plex.rb
+++ b/Casks/font-ibm-plex.rb
@@ -1,6 +1,6 @@
 cask 'font-ibm-plex' do
-  version '1.0.2'
-  sha256 '4153e07273f068e8fa4b65304bbac2ba3ce3b4d59d841eaba4cb374931967e00'
+  version '1.1.3'
+  sha256 'e08da821d32842ef6db5166f46792eefd58f36c639549f40e210590375b1cd36'
 
   url "https://github.com/IBM/plex/releases/download/v#{version}/OpenType.zip"
   appcast 'https://github.com/IBM/plex/releases.atom'
@@ -39,6 +39,14 @@ cask 'font-ibm-plex' do
   font 'OpenType/IBM-Plex-Sans-Condensed/IBMPlexSansCondensed-TextItalic.otf'
   font 'OpenType/IBM-Plex-Sans-Condensed/IBMPlexSansCondensed-Thin.otf'
   font 'OpenType/IBM-Plex-Sans-Condensed/IBMPlexSansCondensed-ThinItalic.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-Bold.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-ExtraLight.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-Light.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-Medium.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-Regular.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-SemiBold.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-Text.otf'
+  font 'OpenType/IBM-Plex-Sans-Hebrew/IBMPlexSansHebrew-Thin.otf'
   font 'OpenType/IBM-Plex-Sans/IBMPlexSans-Bold.otf'
   font 'OpenType/IBM-Plex-Sans/IBMPlexSans-BoldItalic.otf'
   font 'OpenType/IBM-Plex-Sans/IBMPlexSans-ExtraLight.otf'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Updating the IBM Plex font family to the current version, v1.1.3.

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
