### PR TITLE
Adds font-encodesans v2.000 with suite

### DIFF
--- a/Casks/font-encodesans-condensed.rb
+++ b/Casks/font-encodesans-condensed.rb
@@ -1,0 +1,23 @@
+cask 'font-encodesans-condensed' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/encodesanscondensed',
+      using:      :svn,
+      trust_cert: true
+  name 'Encode Sans Condensed'
+  homepage 'https://fonts.google.com/specimen/Encode+Sans+Condensed'
+
+  depends_on macos: '>= :sierra'
+
+  font 'EncodeSansCondensed-Black.ttf'
+  font 'EncodeSansCondensed-Bold.ttf'
+  font 'EncodeSansCondensed-ExtraBold.ttf'
+  font 'EncodeSansCondensed-ExtraLight.ttf'
+  font 'EncodeSansCondensed-Light.ttf'
+  font 'EncodeSansCondensed-Medium.ttf'
+  font 'EncodeSansCondensed-Regular.ttf'
+  font 'EncodeSansCondensed-SemiBold.ttf'
+  font 'EncodeSansCondensed-Thin.ttf'
+end

--- a/Casks/font-encodesans-expanded.rb
+++ b/Casks/font-encodesans-expanded.rb
@@ -1,0 +1,23 @@
+cask 'font-encodesans-expanded' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/encodesansexpanded',
+      using:      :svn,
+      trust_cert: true
+  name 'Encode Sans Expanded'
+  homepage 'https://fonts.google.com/specimen/Encode+Sans+Expanded'
+
+  depends_on macos: '>= :sierra'
+
+  font 'EncodeSansExpanded-Black.ttf'
+  font 'EncodeSansExpanded-Bold.ttf'
+  font 'EncodeSansExpanded-ExtraBold.ttf'
+  font 'EncodeSansExpanded-ExtraLight.ttf'
+  font 'EncodeSansExpanded-Light.ttf'
+  font 'EncodeSansExpanded-Medium.ttf'
+  font 'EncodeSansExpanded-Regular.ttf'
+  font 'EncodeSansExpanded-SemiBold.ttf'
+  font 'EncodeSansExpanded-Thin.ttf'
+end

--- a/Casks/font-encodesans-semicondensed.rb
+++ b/Casks/font-encodesans-semicondensed.rb
@@ -1,0 +1,23 @@
+cask 'font-encodesans-semicondensed' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/encodesanssemicondensed',
+      using:      :svn,
+      trust_cert: true
+  name 'Encode Sans Semi Condensed'
+  homepage 'https://fonts.google.com/specimen/Encode+Sans+Semi+Condensed'
+
+  depends_on macos: '>= :sierra'
+
+  font 'EncodeSansSemiCondensed-Black.ttf'
+  font 'EncodeSansSemiCondensed-Bold.ttf'
+  font 'EncodeSansSemiCondensed-ExtraBold.ttf'
+  font 'EncodeSansSemiCondensed-ExtraLight.ttf'
+  font 'EncodeSansSemiCondensed-Light.ttf'
+  font 'EncodeSansSemiCondensed-Medium.ttf'
+  font 'EncodeSansSemiCondensed-Regular.ttf'
+  font 'EncodeSansSemiCondensed-SemiBold.ttf'
+  font 'EncodeSansSemiCondensed-Thin.ttf'
+end

--- a/Casks/font-encodesans-semiexpanded.rb
+++ b/Casks/font-encodesans-semiexpanded.rb
@@ -1,0 +1,23 @@
+cask 'font-encodesans-semiexpanded' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/encodesanssemiexpanded',
+      using:      :svn,
+      trust_cert: true
+  name 'Encode Sans Semi Expanded'
+  homepage 'https://fonts.google.com/specimen/Encode+Sans+Semi+Expanded'
+
+  depends_on macos: '>= :sierra'
+
+  font 'EncodeSansSemiExpanded-Black.ttf'
+  font 'EncodeSansSemiExpanded-Bold.ttf'
+  font 'EncodeSansSemiExpanded-ExtraBold.ttf'
+  font 'EncodeSansSemiExpanded-ExtraLight.ttf'
+  font 'EncodeSansSemiExpanded-Light.ttf'
+  font 'EncodeSansSemiExpanded-Medium.ttf'
+  font 'EncodeSansSemiExpanded-Regular.ttf'
+  font 'EncodeSansSemiExpanded-SemiBold.ttf'
+  font 'EncodeSansSemiExpanded-Thin.ttf'
+end

--- a/Casks/font-encodesans.rb
+++ b/Casks/font-encodesans.rb
@@ -1,0 +1,23 @@
+cask 'font-encodesans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/encodesans',
+      using:      :svn,
+      trust_cert: true
+  name 'Encode Sans'
+  homepage 'https://fonts.google.com/specimen/Encode+Sans'
+
+  depends_on macos: '>= :sierra'
+
+  font 'EncodeSans-Black.ttf'
+  font 'EncodeSans-Bold.ttf'
+  font 'EncodeSans-ExtraBold.ttf'
+  font 'EncodeSans-ExtraLight.ttf'
+  font 'EncodeSans-Light.ttf'
+  font 'EncodeSans-Medium.ttf'
+  font 'EncodeSans-Regular.ttf'
+  font 'EncodeSans-SemiBold.ttf'
+  font 'EncodeSans-Thin.ttf'
+end


### PR DESCRIPTION
Pulls in the whole suite from Google Fonts.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256