### PR TITLE
Update Source Serif Pro to 2.007R-ro/1.007R-it

### DIFF
--- a/Casks/font-source-serif-pro.rb
+++ b/Casks/font-source-serif-pro.rb
@@ -1,6 +1,6 @@
 cask 'font-source-serif-pro' do
-  version '2.000R'
-  sha256 '2094c6a07953f8877c6a0ce160b0b7d5ec394fc3b19c67d301173d0a94a928c1'
+  version '2.007R-ro%2F1.007R-it'
+  sha256 '46d9b5114e3e86b24769729e2fe09288b6a94c2d4f28a7e39ef572fbe2bec2da'
 
   # github.com/adobe-fonts/source-serif-pro was verified as official when first introduced to the cask
   url "https://github.com/adobe-fonts/source-serif-pro/archive/#{version}.zip"
@@ -8,10 +8,15 @@ cask 'font-source-serif-pro' do
   name 'Source Serif Pro'
   homepage 'https://adobe-fonts.github.io/source-serif-pro/'
 
-  font "source-serif-pro-#{version}/OTF/SourceSerifPro-Black.otf"
-  font "source-serif-pro-#{version}/OTF/SourceSerifPro-Bold.otf"
-  font "source-serif-pro-#{version}/OTF/SourceSerifPro-ExtraLight.otf"
-  font "source-serif-pro-#{version}/OTF/SourceSerifPro-Light.otf"
-  font "source-serif-pro-#{version}/OTF/SourceSerifPro-Regular.otf"
-  font "source-serif-pro-#{version}/OTF/SourceSerifPro-Semibold.otf"
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Black.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-BlackIt.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Bold.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-BoldIt.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-ExtraLight.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-ExtraLightIt.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-It.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Light.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-LightIt.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Regular.otf'
+  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Semibold.otf'
 end


### PR DESCRIPTION
**Issue**

Source Serif Pro’s new version includes a `/`, so the URL and the `.zip` don’t look the same any longer. In the URL, the `/` is escaped as `%2F`, but in the file name it’s escaped as `-`. I hard coded the version in the files, but maybe there is a better solution.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
