### PR TITLE
Fix unzip errors occurred in font-myrica and font-myricam installation

### DIFF
--- a/Casks/font-myrica.rb
+++ b/Casks/font-myrica.rb
@@ -1,9 +1,12 @@
+# Donwload a tar.gz archive instead of a zip archive.  There are japanese
+# characters in files contained in the downloaded archive, and that makes errors
+# while unarchiving.
 cask 'font-myrica' do
   version '2.006.20150301'
-  sha256 'ac85d476a7a8cc809be015b9593afff2d998e7cea3b9fd9aee7d9d9a05ba449b'
+  sha256 'a90eb9b79885f02ad9e0e752a0b979b699847be7de13dc3b6113658f006d12bd'
 
   # codeload.github.com/tomokuni/Myrica was verified as official when first introduced to the cask
-  url "https://codeload.github.com/tomokuni/Myrica/zip/#{version}"
+  url "https://codeload.github.com/tomokuni/Myrica/tar.gz/#{version}"
   appcast 'https://github.com/tomokuni/Myrica/releases.atom'
   name 'Myrica'
   homepage 'http://myrica.estable.jp/'

--- a/Casks/font-myricam.rb
+++ b/Casks/font-myricam.rb
@@ -1,9 +1,12 @@
+# Donwload a tar.gz archive instead of a zip archive.  There are japanese
+# characters in files contained in the downloaded archive, and that makes errors
+# while unarchiving.
 cask 'font-myricam' do
   version '2.006.20150301'
-  sha256 'ac85d476a7a8cc809be015b9593afff2d998e7cea3b9fd9aee7d9d9a05ba449b'
+  sha256 'a90eb9b79885f02ad9e0e752a0b979b699847be7de13dc3b6113658f006d12bd'
 
   # codeload.github.com/tomokuni/Myrica was verified as official when first introduced to the cask
-  url "https://codeload.github.com/tomokuni/Myrica/zip/#{version}"
+  url "https://codeload.github.com/tomokuni/Myrica/tar.gz/#{version}"
   appcast 'https://github.com/tomokuni/Myrica/releases.atom'
   name 'MyricaM'
   homepage 'http://myrica.estable.jp/'


### PR DESCRIPTION
Donwload a tar.gz archive instead of a zip archive.

There are japanese characters in files contained in the downloaded archive, and that makes errors while unarchiving.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
