### PR TITLE
Add cask for Sans Forgetica font

### DIFF
--- a/Casks/font-sans-forgetica
+++ b/Casks/font-sans-forgetica
@@ -1,0 +1,12 @@
+cask 'font-sans-forgetica' do
+  version :latest
+  sha256 :no_check
+
+  url "http://sansforgetica.rmit/Common/Zips/Sans%20Forgetica.zip"
+  name 'Sans Forgetica'
+  homepage 'http://sansforgetica.rmit/'
+
+  container type: :zip
+
+  font "Sans Forgetica/SansForgetica-Regular.otf"
+end

--- a/Casks/font-sans-forgetica.rb
+++ b/Casks/font-sans-forgetica.rb
@@ -2,9 +2,9 @@ cask 'font-sans-forgetica' do
   version :latest
   sha256 :no_check
 
-  url "http://sansforgetica.rmit/Common/Zips/Sans%20Forgetica.zip"
+  url 'http://sansforgetica.rmit/Common/Zips/Sans%20Forgetica.zip'
   name 'Sans Forgetica'
   homepage 'http://sansforgetica.rmit/'
 
-  font "Sans Forgetica/SansForgetica-Regular.otf"
+  font 'Sans Forgetica/SansForgetica-Regular.otf'
 end

--- a/Casks/font-sans-forgetica.rb
+++ b/Casks/font-sans-forgetica.rb
@@ -6,7 +6,5 @@ cask 'font-sans-forgetica' do
   name 'Sans Forgetica'
   homepage 'http://sansforgetica.rmit/'
 
-  container type: :zip
-
   font "Sans Forgetica/SansForgetica-Regular.otf"
 end


### PR DESCRIPTION
Sans Forgetica is a font that, according to [its homepage](http://sansforgetica.rmit/), is "scientifically designed to help you remember your study notes."

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Cask is a stable version
- [x] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].