### PR TITLE
Update duospace path

### DIFF
--- a/Casks/font-ia-writer-duospace.rb
+++ b/Casks/font-ia-writer-duospace.rb
@@ -9,5 +9,5 @@ cask 'font-ia-writer-duospace' do
   font 'iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-Bold.otf'
   font 'iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-BoldItalic.otf'
   font 'iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-Regular.otf'
-  font 'iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-RegularItalic.otf'
+  font 'iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-Italic.otf'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

------

iA-Fonts [recently changed](https://github.com/iaolo/iA-Fonts/commit/549d8283c0ed1b29461553139861a8f0a4c458dd#diff-17ac9d78424ac1bf8ec1acba6196ac94) the path for `-RegularItalic.otf` to just `-Italic.otf` and installation of the font is currently failing due to missing file. This commit update the path for Italic font and fix the installation issue.