### PR TITLE
Fix broken download links of PT Sans, PT Serif and PT Mono

### DIFF
--- a/Casks/font-pt-mono.rb
+++ b/Casks/font-pt-mono.rb
@@ -1,11 +1,11 @@
-cask 'font-pt-mono' do
+cask "font-pt-mono" do
   version :latest
   sha256 :no_check
 
-  url 'https://company.paratype.com/system/attachments/631/original/ptmono.zip'
-  name 'PT Mono'
-  homepage 'https://www.paratype.com/public/'
+  url "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
+  name "PT Mono"
+  homepage "https://www.paratype.com/public/"
 
-  font 'PTM55F.ttf'
-  font 'PTM75F.ttf'
+  font "PTM55F.ttf"
+  font "PTM75F.ttf"
 end

--- a/Casks/font-pt-mono.rb
+++ b/Casks/font-pt-mono.rb
@@ -2,7 +2,7 @@ cask 'font-pt-mono' do
   version :latest
   sha256 :no_check
 
-  url 'https://old.paratype.com/uni/public/PTMono.zip'
+  url 'https://company.paratype.com/system/attachments/631/original/ptmono.zip'
   name 'PT Mono'
   homepage 'https://www.paratype.com/public/'
 

--- a/Casks/font-pt-sans.rb
+++ b/Casks/font-pt-sans.rb
@@ -2,7 +2,7 @@ cask 'font-pt-sans' do
   version :latest
   sha256 :no_check
 
-  url 'https://old.paratype.com/uni/public/PTSans.zip'
+  url 'https://company.paratype.com/system/attachments/629/original/ptsans.zip'
   name 'PT Sans'
   homepage 'https://www.paratype.com/public/'
 

--- a/Casks/font-pt-sans.rb
+++ b/Casks/font-pt-sans.rb
@@ -1,17 +1,17 @@
-cask 'font-pt-sans' do
+cask "font-pt-sans" do
   version :latest
   sha256 :no_check
 
-  url 'https://company.paratype.com/system/attachments/629/original/ptsans.zip'
-  name 'PT Sans'
-  homepage 'https://www.paratype.com/public/'
+  url "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
+  name "PT Sans"
+  homepage "https://www.paratype.com/public/"
 
-  font 'PTC55F.ttf'
-  font 'PTC75F.ttf'
-  font 'PTN57F.ttf'
-  font 'PTN77F.ttf'
-  font 'PTS55F.ttf'
-  font 'PTS56F.ttf'
-  font 'PTS75F.ttf'
-  font 'PTS76F.ttf'
+  font "PTC55F.ttf"
+  font "PTC75F.ttf"
+  font "PTN57F.ttf"
+  font "PTN77F.ttf"
+  font "PTS55F.ttf"
+  font "PTS56F.ttf"
+  font "PTS75F.ttf"
+  font "PTS76F.ttf"
 end

--- a/Casks/font-pt-serif.rb
+++ b/Casks/font-pt-serif.rb
@@ -1,15 +1,15 @@
-cask 'font-pt-serif' do
+cask "font-pt-serif" do
   version :latest
   sha256 :no_check
 
-  url 'https://company.paratype.com/system/attachments/634/original/ptserif.zip'
-  name 'PT Serif'
-  homepage 'https://www.paratype.com/public/'
+  url "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
+  name "PT Serif"
+  homepage "https://www.paratype.com/public/"
 
-  font 'PTF55F.ttf'
-  font 'PTF56F.ttf'
-  font 'PTF75F.ttf'
-  font 'PTF76F.ttf'
-  font 'PTZ55F.ttf'
-  font 'PTZ56F.ttf'
+  font "PTF55F.ttf"
+  font "PTF56F.ttf"
+  font "PTF75F.ttf"
+  font "PTF76F.ttf"
+  font "PTZ55F.ttf"
+  font "PTZ56F.ttf"
 end

--- a/Casks/font-pt-serif.rb
+++ b/Casks/font-pt-serif.rb
@@ -2,7 +2,7 @@ cask 'font-pt-serif' do
   version :latest
   sha256 :no_check
 
-  url 'https://old.paratype.com/uni/public/PTSerif.zip'
+  url 'https://company.paratype.com/system/attachments/634/original/ptserif.zip'
   name 'PT Serif'
   homepage 'https://www.paratype.com/public/'
 


### PR DESCRIPTION
Old links return a 404 error. I changed them to the links provided on the page [https://company.paratype.com/pt-sans-pt-serif](https://company.paratype.com/pt-sans-pt-serif). It's the same page you are redirect to when opening casks homepages.

After making all changes to the cask:

- [✓] `brew cask audit --download {{cask_file}}` is error-free.
- [✓] `brew cask style --fix {{cask_file}}` reports no offenses.
- [✓] The commit message includes the cask’s name and version. (**only the name**)
- [✓] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256