### PR TITLE
Fix broken download link of font-pt-sans

### DIFF
--- a/Casks/font-pt-sans.rb
+++ b/Casks/font-pt-sans.rb
@@ -2,7 +2,7 @@ cask 'font-pt-sans' do
   version :latest
   sha256 :no_check
 
-  url 'https://old.paratype.com/uni/public/PTSans.zip'
+  url 'https://company.paratype.com/system/attachments/629/original/ptsans.zip'
   name 'PT Sans'
   homepage 'https://www.paratype.com/public/'
 


### PR DESCRIPTION
The old link returns a 404 error. This commit replaces it with the link
in the official page (https://company.paratype.com/pt-sans-pt-serif).

(I tried to follow the suggestions in #1749 🙂)
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. (**only the name**)
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256