### PR TITLE
Update font-source-han-sans to 2.0000

### DIFF
--- a/Casks/font-source-han-sans.rb
+++ b/Casks/font-source-han-sans.rb
@@ -1,8 +1,8 @@
 cask 'font-source-han-sans' do
-  version '1.004'
-  sha256 'b684c9b659ec4998e72d22ff5ed3f531d31d506ae00a48ec72b9846be23e7c10'
+  version '2.000'
+  sha256 '500a516d67ec25328f9bd9e357f7ee14bfa560372b6002b76b18749207469da9'
 
-  url 'https://github.com/adobe-fonts/source-han-sans/raw/5f5311e71cb628321cc0cffb51fb38d862b726aa/SuperOTC/SourceHanSans.ttc.zip'
+  url 'https://github.com/adobe-fonts/source-han-sans/raw/2.000R/SuperOTC/SourceHanSans.ttc.zip'
   name 'Source Han Sans'
   homepage 'https://github.com/adobe-fonts/source-han-sans'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
  My system (macOS 10.12.6) is broken, it fails installing rubocop.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
