### PR TITLE
Update URL for PT Mono

### DIFF
--- a/Casks/font-pt-mono.rb
+++ b/Casks/font-pt-mono.rb
@@ -2,7 +2,7 @@ cask 'font-pt-mono' do
   version :latest
   sha256 :no_check
 
-  url 'https://old.paratype.com/uni/public/PTMono.zip'
+  url 'https://company.paratype.com/system/attachments/631/original/ptmono.zip'
   name 'PT Mono'
   homepage 'https://www.paratype.com/public/'
 


### PR DESCRIPTION
Old URL 404s (https://old.paratype.com/uni/public/PTMono.zip)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.