### PR TITLE
Update font-amiri to 0.111

### DIFF
--- a/Casks/font-amiri.rb
+++ b/Casks/font-amiri.rb
@@ -3,13 +3,15 @@ cask 'font-amiri' do
   sha256 '1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166'
 
   # github.com/alif-type/amiri-font was verified as official when first introduced to the cask
-  url "https://github.com/alif-type/amiri-font/releases/download/#{version}/amiri-#{version}.zip"
+  url "https://github.com/alif-type/amiri-font/releases/download/#{version}/Amiri-#{version}.zip"
   appcast 'https://github.com/alif-type/amiri/releases.atom'
   name 'Amiri'
   homepage 'https://www.amirifont.org/'
 
-  font "amiri-#{version}/amiri-bold.ttf"
-  font "amiri-#{version}/amiri-boldslanted.ttf"
-  font "amiri-#{version}/amiri-quran.ttf"
-  font "amiri-#{version}/amiri-regular.ttf"
+  font "Amiri-#{version}/Amiri-Bold.ttf"
+  font "Amiri-#{version}/Amiri-BoldSlanted.ttf"
+  font "Amiri-#{version}/Amiri-Regular.ttf"
+  font "Amiri-#{version}/Amiri-Slanted.ttf"
+  font "Amiri-#{version}/AmiriQuran.ttf"
+  font "Amiri-#{version}/AmiriQuranColored.ttf"
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
Partially addresses #1757 by updating the font names.