### PR TITLE
Update font-didact-gothic to 2.101

### DIFF
--- a/Casks/font-didact-gothic.rb
+++ b/Casks/font-didact-gothic.rb
@@ -1,5 +1,5 @@
 cask 'font-didact-gothic' do
-  version '20110429'
+  version '2.101'
   sha256 'b98f9e091b6337a86f4e0f69c94c31905e1e287782853f472e176b4e28d3f81f'
 
   # github.com/google/fonts was verified as official when first introduced to the cask
@@ -7,5 +7,5 @@ cask 'font-didact-gothic' do
   name 'Didact Gothic'
   homepage 'https://www.google.com/fonts/specimen/Didact%20Gothic'
 
-  font 'DidactGothic.ttf'
+  font 'DidactGothic-Regular.ttf'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
Partially addresses #1757 by changing the font name. Also, the version number now matches with the git commit messages; no SHA256 change.