### PR TITLE
Update font-parastoo to 1.0.0-alpha5

### DIFF
--- a/Casks/font-parastoo.rb
+++ b/Casks/font-parastoo.rb
@@ -8,6 +8,6 @@ cask 'font-parastoo' do
   name 'Parastoo'
   homepage 'https://rastikerdar.github.io/parastoo-font'
 
-  font 'Parastoo.ttf'
-  font 'Parastoo-Bold.ttf'
+  font 'web/Parastoo.ttf'
+  font 'web/Parastoo-Bold.ttf'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
---
Partially addresses #1757 by changing the font naming structure; now the zip file includes a folder.