### PR TITLE
Add/tweak probots configuration.

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -10,6 +10,6 @@ lockComment: false
 # Limit to only `issues` or `pulls`
 # only: issues
 # Add a label when locking. Set to `false` to disable
-lockLabel: false
+lockLabel: outdated
 # Assign `resolved` as the reason for locking. Set to `false` to disable
-setLockReason: false
+setLockReason: resolved

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 21
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - gsoc-outreachy
+  - help wanted
+  - in progress
+# Label to use when marking as stale
+staleLabel: stale
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,16 @@
+# Configuration for support-requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: support request
+# Comment to post on issues marked as support requests. Add a link
+# to a support page, or set to `false` to disable
+supportComment: >
+  We use the issue tracker exclusively for bug reports.
+  However, this issue appears to be a support request. Please use our
+  [Discourse](https://discourse.brew.sh) or
+  [IRC channel](irc://irc.freenode.net/#machomebrew) to get help with
+  the project.
+# Whether to close issues marked as support requests
+close: true
+# Whether to lock issues marked as support requests
+lock: true


### PR DESCRIPTION
This adds the other probots used by the main Homebrew Cask tap and tweaks the
existing configuration to be consistent with the main Homebrew Cask tap.