### PR TITLE
Add missing styles to font-ubuntumono-nerd-font.rb

### DIFF
--- a/Casks/font-ubuntumono-nerd-font.rb
+++ b/Casks/font-ubuntumono-nerd-font.rb
@@ -8,4 +8,7 @@ cask 'font-ubuntumono-nerd-font' do
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 
   font 'Ubuntu Mono Nerd Font Complete.ttf'
+  font 'Ubuntu Mono Italic Nerd Font Complete.ttf'
+  font 'Ubuntu Mono Bold Nerd Font Complete.ttf'
+  font 'Ubuntu Mono Bold Italic Nerd Font Complete.ttf'
 end


### PR DESCRIPTION
The following styles for `font-ubuntumono-nerd-font` (version 2.0.0), which are available in the downloaded archive `UbuntuMono.zip`, should be installed too:

- Ubuntu Mono Italic Nerd Font Complete.ttf
- Ubuntu Mono Bold Nerd Font Complete.ttf
- Ubuntu Mono Bold Italic Nerd Font Complete.ttf

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).