### PR TITLE
Use upstream Foundry source for ASAP

### DIFF
--- a/Casks/font-asap.rb
+++ b/Casks/font-asap.rb
@@ -2,18 +2,18 @@ cask 'font-asap' do
   version :latest
   sha256 :no_check
 
-  # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/ofl/asap',
-      using:      :svn,
-      revision:   '50',
-      trust_cert: true
+  url 'https://www.omnibus-type.com/wp-content/uploads/Asap.zip'
   name 'Asap'
-  homepage 'https://www.google.com/fonts/specimen/Asap'
+  homepage 'https://www.omnibus-type.com/fonts/asap/'
 
   depends_on macos: '>= :sierra'
 
-  font 'Asap-Bold.ttf'
-  font 'Asap-BoldItalic.ttf'
-  font 'Asap-Italic.ttf'
-  font 'Asap-Regular.ttf'
+  font 'Asap/Asap-Bold.ttf'
+  font 'Asap/Asap-BoldItalic.ttf'
+  font 'Asap/Asap-Italic.ttf'
+  font 'Asap/Asap-Medium.ttf'
+  font 'Asap/Asap-MediumItalic.ttf'
+  font 'Asap/Asap-Regular.ttf'
+  font 'Asap/Asap-SemiBold.ttf'
+  font 'Asap/Asap-SemiBoldItalic.ttf'
 end


### PR DESCRIPTION
ASAP is produced by Omnibus Type and licensed as OFL 1.1 so it should be cleared for distribution direct from the foundry. The upstream source also has more weights and is more up-to-date than Google Fonts.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
    + ASAP is in the commit message, but there is no version to mention
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
    + ASAP is unversioned

