### PR TITLE
add SemiBold and ExtraBold to inter v3.3

### DIFF
--- a/Casks/font-inter.rb
+++ b/Casks/font-inter.rb
@@ -12,8 +12,12 @@ cask 'font-inter' do
   font 'Inter (OTF)/Inter-BlackItalic.otf'
   font 'Inter (OTF)/Inter-Bold.otf'
   font 'Inter (OTF)/Inter-BoldItalic.otf'
+  font 'Inter (OTF)/Inter-ExtraBold.otf'
+  font 'Inter (OTF)/Inter-ExtraBoldItalic.otf'
   font 'Inter (OTF)/Inter-Italic.otf'
   font 'Inter (OTF)/Inter-Medium.otf'
   font 'Inter (OTF)/Inter-MediumItalic.otf'
   font 'Inter (OTF)/Inter-Regular.otf'
+  font 'Inter (OTF)/Inter-SemiBold.otf'
+  font 'Inter (OTF)/Inter-SemiBoldItalic.otf'
 end


### PR DESCRIPTION
did not add other font weights yet as they are in BETA

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
