### PR TITLE
Change font-public-sans source to latest

### DIFF
--- a/Casks/font-public-sans.rb
+++ b/Casks/font-public-sans.rb
@@ -1,29 +1,28 @@
 cask 'font-public-sans' do
-  version '1.0.0'
-  sha256 'f2ae81c5e3949e867957abac962588fece769bba04e34eb2328a7a1962034fba'
+  version :latest
+  sha256 :no_check
 
   # github.com/uswds/public-sans was verified as official when first introduced to the cask
-  url "https://github.com/uswds/public-sans/releases/download/v#{version}/public-sans-v#{version}.zip"
-  appcast 'https://github.com/uswds/public-sans/releases.atom'
+  url 'https://codeload.github.com/uswds/public-sans/zip/master'
   name 'Public Sans'
   homepage 'https://18franklin.18f.gov/'
 
-  font "public-sans-#{version}/fonts/otf/PublicSans-Black.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-BlackItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-Bold.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-BoldItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-ExtraBold.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-ExtraBoldItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-ExtraLight.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-ExtraLightItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-Italic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-Light.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-LightItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-Medium.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-MediumItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-Regular.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-SemiBold.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-SemiBoldItalic.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-Thin.otf"
-  font "public-sans-#{version}/fonts/otf/PublicSans-ThinItalic.otf"
+  font 'public-sans-master/fonts/otf/PublicSans-Black.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-BlackItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-Bold.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-BoldItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-ExtraBold.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-ExtraBoldItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-ExtraLight.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-ExtraLightItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-Italic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-Light.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-LightItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-Medium.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-MediumItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-Regular.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-SemiBold.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-SemiBoldItalic.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-Thin.otf'
+  font 'public-sans-master/fonts/otf/PublicSans-ThinItalic.otf'
 end


### PR DESCRIPTION
This PR changes [the font-public-sans cask](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-public-sans.rb) (introduced in #1783) to use the latest version from GitHub.

When trying to install the cask with the previous source (using the tagged `v1.0.0` release), I received the following error:

```sh
$ brew cask install font-public-sans
==> Satisfying dependencies
==> Downloading https://github.com/uswds/public-sans/releases/download/v1.0.0/public-sans-v1.0.0.zip
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/72852005/8d2cff80-c877-11e8-98e9-f4571b441731?X-Amz-Alg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'font-public-sans'.
==> Installing Cask font-public-sans
==> Purging files for version 1.0.0 of Cask font-public-sans
Error: It seems the Font source '/usr/local/Caskroom/font-public-sans/1.0.0/public-sans-1.0.0/fonts/otf/PublicSans-ThinItalic.otf' is not there.
```

In testing locally (by cloning this repo and running `brew cask install Casks/font-public-sans.rb`), I received similar errors regardless of how many of the `font` declarations I commented out.

I couldn't figure out a different way to resolve the error, so I switched the cask to use the latest version, straight from the font repository's master branch. Please let me know if there's a better way to address this kind of error!

Thanks for your consideration.