### PR TITLE
add font-blackout

### DIFF
--- a/Casks/font-blackout.rb
+++ b/Casks/font-blackout.rb
@@ -1,0 +1,13 @@
+cask 'font-blackout' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/theleagueof/blackout was verified as official when first introduced to the cask
+  url 'https://github.com/theleagueof/blackout/archive/master.zip'
+  name 'Blackout'
+  homepage 'https://www.theleagueofmoveabletype.com/blackout'
+
+  font 'blackout-master/Blackout 2 AM.ttf'
+  font 'blackout-master/Blackout Midnight.ttf'
+  font 'blackout-master/Blackout Sunrise.ttf'
+end


### PR DESCRIPTION
Blackout is OFL 1.1 licensed and should be cleared for distribution by the creators ([The League of Movable Type](https://www.theleagueofmoveabletype.com/)).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
    + kinda! It's an unversioned font.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
    - The release is as stable as it can be for an unversioned font

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
