### PR TITLE
Add font-titillium 2.0

### DIFF
--- a/Casks/font-titillium.rb
+++ b/Casks/font-titillium.rb
@@ -1,0 +1,26 @@
+cask 'font-titillium' do
+  version '2.0'
+  sha256 '649fb98c5fca9967d18c3243aa549c9c460cbf3ea6dd4ccd46c970f3585a7225'
+
+  # src.fedoraproject.org was verified as official when first introduced to the cask
+  url 'https://src.fedoraproject.org/repo/extras/campivisivi-titillium-fonts/Titillium_roman_upright_italic_2_0_OT.zip/258e06fe34c35320321f0458e6625bba/Titillium_roman_upright_italic_2_0_OT.zip'
+  name 'Titillium'
+  homepage 'http://nta.accademiadiurbino.it/titillium.html'
+
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-Black.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-Bold.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-BoldItalic.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-BoldUpright.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-Light.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-LightItalic.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-LightUpright.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-Regular.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-RegularItalic.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-RegularUpright.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-Semibold.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-SemiboldItalic.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-SemiboldUpright.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-Thin.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-ThinItalic.otf'
+  font 'Titillium_roman_upright_italic_2_0_OT/Titillium-ThinUpright.otf'
+end


### PR DESCRIPTION
The mirror is used because the official download site has been down since 2016.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
