### PR TITLE
Update font-ipaexfont from 003.01 to 004.01

### DIFF
--- a/Casks/font-ipaexfont.rb
+++ b/Casks/font-ipaexfont.rb
@@ -1,6 +1,6 @@
 cask 'font-ipaexfont' do
-  version '003.01'
-  sha256 'c7de095cfded3a549b439b7874cc21b8d73aa16a40d15c31b87bfe0c02f4ae5a'
+  version '004.01'
+  sha256 'bcf8374ab3f9672c421120430dd19a51c99f5265cf06fc340d9a661ddfd7974b'
 
   url "https://oscdl.ipa.go.jp/IPAexfont/IPAexfont#{version.no_dots}.zip"
   name 'IPAex Fonts'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.