### PR TITLE
The download URLs for Courier Prime fonts have changed

### DIFF
--- a/Casks/font-courier-prime-code.rb
+++ b/Casks/font-courier-prime-code.rb
@@ -2,7 +2,7 @@ cask 'font-courier-prime-code' do
   version :latest
   sha256 :no_check
 
-  url 'https://quoteunquoteapps.com/downloads/courier-code.zip'
+  url 'https://quoteunquoteapps.com/courierprime/downloads/courier-prime-code.zip'
   name 'Courier Prime Code'
   homepage 'https://quoteunquoteapps.com/courierprime/#code-sans'
 

--- a/Casks/font-courier-prime-medium-and-semi-bold.rb
+++ b/Casks/font-courier-prime-medium-and-semi-bold.rb
@@ -2,7 +2,7 @@ cask 'font-courier-prime-medium-and-semi-bold' do
   version :latest
   sha256 :no_check
 
-  url 'https://quoteunquoteapps.com/courierprime/Courier-Prime-Medium-Semi-Bold.zip'
+  url 'https://quoteunquoteapps.com/courierprime/downloads/courier-prime-medium-semi-bold.zip'
   name 'Courier Prime Medium & Semi-Bold'
   homepage 'https://quoteunquoteapps.com/courierprime/#cyrillic-semi-bold'
 

--- a/Casks/font-courier-prime-sans.rb
+++ b/Casks/font-courier-prime-sans.rb
@@ -2,7 +2,7 @@ cask 'font-courier-prime-sans' do
   version :latest
   sha256 :no_check
 
-  url 'https://quoteunquoteapps.com/downloads/courier-sans.zip'
+  url 'https://quoteunquoteapps.com/courierprime/downloads/courier-prime-sans.zip'
   name 'Courier Prime Sans'
   homepage 'https://quoteunquoteapps.com/courierprime/#code-sans'
 

--- a/Casks/font-courier-prime.rb
+++ b/Casks/font-courier-prime.rb
@@ -2,7 +2,7 @@ cask 'font-courier-prime' do
   version :latest
   sha256 :no_check
 
-  url 'https://quoteunquoteapps.com/downloads/courier-prime.zip'
+  url 'https://quoteunquoteapps.com/courierprime/downloads/courier-prime.zip'
   name 'Courier Prime'
   homepage 'https://quoteunquoteapps.com/courierprime/'
 


### PR DESCRIPTION
After making all changes to the casks:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for a font with no specific versioning.
- [x] The casks install.