### PR TITLE
Victor Mono updated to latest version with multiple weights

### DIFF
--- a/Casks/font-victor-mono.rb
+++ b/Casks/font-victor-mono.rb
@@ -2,11 +2,29 @@ cask 'font-victor-mono' do
   version :latest
   sha256 :no_check
 
-  url 'https://rubjo.github.io/victor-mono/Victor%20Mono.zip'
+  url 'https://rubjo.github.io/victor-mono/VictorMonoAll.zip'
   name 'Victor Mono'
   homepage 'https://rubjo.github.io/victor-mono/'
 
-  font 'VictorMono-Regular.otf'
-  font 'VictorMono-Oblique.otf'
-  font 'VictorMono-Italic.otf'
+  font 'OTF/VictorMono-Thin.otf'
+  font 'OTF/VictorMono-ExtraLight.otf'
+  font 'OTF/VictorMono-Light.otf'
+  font 'OTF/VictorMono-Regular.otf'
+  font 'OTF/VictorMono-Medium.otf'
+  font 'OTF/VictorMono-SemiBold.otf'
+  font 'OTF/VictorMono-Bold.otf'
+  font 'OTF/VictorMono-ObliqueThin.otf'
+  font 'OTF/VictorMono-ObliqueExtraLight.otf'
+  font 'OTF/VictorMono-ObliqueLight.otf'
+  font 'OTF/VictorMono-ObliqueRegular.otf'
+  font 'OTF/VictorMono-ObliqueMedium.otf'
+  font 'OTF/VictorMono-ObliqueSemiBold.otf'
+  font 'OTF/VictorMono-ObliqueBold.otf'
+  font 'OTF/VictorMono-ItalicThin.otf'
+  font 'OTF/VictorMono-ItalicExtraLight.otf'
+  font 'OTF/VictorMono-ItalicLight.otf'
+  font 'OTF/VictorMono-ItalicRegular.otf'
+  font 'OTF/VictorMono-ItalicMedium.otf'
+  font 'OTF/VictorMono-ItalicSemiBold.otf'
+  font 'OTF/VictorMono-ItalicBold.otf'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
