### PR TITLE
Update font-source-serif-pro.rb to V3.000

### DIFF
--- a/Casks/font-source-serif-pro.rb
+++ b/Casks/font-source-serif-pro.rb
@@ -1,22 +1,23 @@
 cask 'font-source-serif-pro' do
-  version '2.007R-ro,1.007R-it'
-  sha256 '46d9b5114e3e86b24769729e2fe09288b6a94c2d4f28a7e39ef572fbe2bec2da'
+  version '3.000R'
+  sha256 '6f3135849ece74461994bd57e5e7acf3da0f8d8c96ef94b5f3bb3e91f7d155cc'
 
   # github.com/adobe-fonts/source-serif-pro was verified as official when first introduced to the cask
-  url "https://github.com/adobe-fonts/source-serif-pro/archive/#{version.before_comma}/#{version.after_comma}.zip"
+  url "https://github.com/adobe-fonts/source-serif-pro/releases/download/#{version}/source-serif-pro-#{version}.zip"
   appcast 'https://github.com/adobe-fonts/source-serif-pro/releases.atom'
   name 'Source Serif Pro'
   homepage 'https://adobe-fonts.github.io/source-serif-pro/'
 
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Black.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-BlackIt.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Bold.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-BoldIt.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-ExtraLight.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-ExtraLightIt.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-It.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Light.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-LightIt.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Regular.otf'
-  font 'source-serif-pro-2.007R-ro-1.007R-it/OTF/SourceSerifPro-Semibold.otf'
+  font 'OTF/SourceSerifPro-Black.otf'
+  font 'OTF/SourceSerifPro-BlackIt.otf'
+  font 'OTF/SourceSerifPro-Bold.otf'
+  font 'OTF/SourceSerifPro-BoldIt.otf'
+  font 'OTF/SourceSerifPro-ExtraLight.otf'
+  font 'OTF/SourceSerifPro-ExtraLightIt.otf'
+  font 'OTF/SourceSerifPro-It.otf'
+  font 'OTF/SourceSerifPro-Light.otf'
+  font 'OTF/SourceSerifPro-LightIt.otf'
+  font 'OTF/SourceSerifPro-Regular.otf'
+  font 'OTF/SourceSerifPro-Semibold.otf'
+  font 'OTF/SourceSerifPro-SemiboldIt.otf'
 end


### PR DESCRIPTION
Update to V3.000, I had to change the download URL slightly as the previous template downloads the source for 3.000 not the release itself...

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free. 
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
