### PR TITLE
font-redhat 2.3.1

### DIFF
--- a/Casks/font-redhat.rb
+++ b/Casks/font-redhat.rb
@@ -1,6 +1,6 @@
 cask 'font-redhat' do
-  version '2.2.0'
-  sha256 '5c1bb9cc53343b892bd5cfa32ba6ed1d3bf61c297ec43f326a0680887b2d8d5c'
+  version '2.3.1'
+  sha256 'acd4f9a81368e228c9fd24b0d0f98f0bcc5fbe836c7bef78c685c31b749ed7f4'
 
   url "https://github.com/RedHatOfficial/RedHatFont/archive/#{version}.tar.gz"
   appcast 'https://github.com/RedHatOfficial/RedHatFont/releases.atom'


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).