### PR TITLE
secure urls

### DIFF
--- a/Casks/font-hanamina.rb
+++ b/Casks/font-hanamina.rb
@@ -2,8 +2,8 @@ cask 'font-hanamina' do
   version '2017.09.04,68253'
   sha256 '571cd4a09ae7da0c642d640fc2442c050aa450ebb0587a95cdd097d41a9c9572'
 
-  # dl.osdn.jp/hanazono-font was verified as official when first introduced to the cask
-  url "http://dl.osdn.jp/hanazono-font/#{version.after_comma}/hanazono-#{version.before_comma.no_dots}.zip"
+  # osdn.dl.osdn.jp/hanazono-font was verified as official when first introduced to the cask
+  url "https://osdn.dl.osdn.jp/hanazono-font/#{version.after_comma}/hanazono-#{version.before_comma.no_dots}.zip"
   name 'HanaMinA'
   homepage 'https://fonts.jp/hanazono/'
 

--- a/Casks/font-input.rb
+++ b/Casks/font-input.rb
@@ -4,9 +4,9 @@ cask 'font-input' do
 
   # the served font is built dynamically, according to the query string;
   # we pass the default parameters, plus the required license agreement.
-  url 'http://input.fontbureau.com/build/?basic=1&fontSelection=whole&a=0&g=0&i=0&l=0&zero=0&asterisk=0&lineHeight=1.2&accept=I+do'
+  url 'https://input.fontbureau.com/build/?basic=1&fontSelection=whole&a=0&g=0&i=0&l=0&zero=0&asterisk=0&lineHeight=1.2&accept=I+do'
   name 'Input'
-  homepage 'http://input.fontbureau.com/'
+  homepage 'https://input.fontbureau.com/'
 
   font 'Input_Fonts/InputMono/InputMono/InputMono-Black.ttf'
   font 'Input_Fonts/InputMono/InputMono/InputMono-BlackItalic.ttf'
@@ -180,6 +180,6 @@ cask 'font-input' do
   caveats <<~EOS
     To use the Input fonts, you must agree to the terms of the license.
 
-      http://input.fontbureau.com/license/
+      https://input.fontbureau.com/license/
   EOS
 end

--- a/Casks/font-ligature-symbols.rb
+++ b/Casks/font-ligature-symbols.rb
@@ -2,9 +2,9 @@ cask 'font-ligature-symbols' do
   version :latest
   sha256 :no_check
 
-  url 'http://kudakurage.com/ligature_symbols/LigatureSymbols.zip'
+  url 'https://kudakurage.com/ligature_symbols/LigatureSymbols.zip'
   name 'Ligature Symbols'
-  homepage 'http://kudakurage.com/ligature_symbols/'
+  homepage 'https://kudakurage.com/ligature_symbols/'
 
   font 'LigatureSymbols/LigatureSymbols-2.11.otf'
 end

--- a/Casks/font-m-plus.rb
+++ b/Casks/font-m-plus.rb
@@ -2,7 +2,7 @@ cask 'font-m-plus' do
   version '063'
   sha256 '149a5c97c35624d79ffb3cbbdd56559319085229acaf72b49b56adc5ede0979c'
 
-  url "http://dl.osdn.jp/mplus-fonts/62344/mplus-TESTFLIGHT-#{version}.tar.xz"
+  url "https://osdn.dl.osdn.jp/mplus-fonts/62344/mplus-TESTFLIGHT-#{version}.tar.xz"
   name 'M+ FONTS'
   homepage 'https://mplus-fonts.osdn.jp/about-en.html'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
==> Downloading https://osdn.dl.osdn.jp/hanazono-font/68253/hanazono-20170904.zi
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'font-hanamina'.
audit for font-hanamina: passed

1 file inspected, no offenses detected
==> Downloading https://input.fontbureau.com/build/?basic=1&fontSelection=whole&
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'font-input', skipping verification.
audit for font-input: passed

1 file inspected, no offenses detected
==> Downloading https://kudakurage.com/ligature_symbols/LigatureSymbols.zip
######################################################################## 100.0%
==> No SHA-256 checksum defined for Cask 'font-ligature-symbols', skipping verif
audit for font-ligature-symbols: passed

1 file inspected, no offenses detected
==> Downloading https://osdn.dl.osdn.jp/mplus-fonts/62344/mplus-TESTFLIGHT-063.t
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'font-m-plus'.
audit for font-m-plus: passed
```
