### PR TITLE
Add font-fira-code-regular-symbol

### DIFF
--- a/font-fira-code-regular-symbol.rb
+++ b/font-fira-code-regular-symbol.rb
@@ -1,0 +1,10 @@
+cask 'font-fira-code-regular-symbol' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip'
+  name 'font-fira-code-regular-symbol'
+  homepage 'https://github.com/tonsky/FiraCode'
+
+  font 'FiraCode-Regular-Symbol.otf'
+end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

This font is a fallback font created by @siegebell last month and posted [in this comment thread](https://github.com/tonsky/FiraCode/issues/211#issuecomment-239058632). Insofar as I can tell, it doesn't have a version, only a name.

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
