### PR TITLE
Update font-iosevka-slab from 2.2.1 to 2.3.0

### DIFF
--- a/Casks/font-iosevka-slab.rb
+++ b/Casks/font-iosevka-slab.rb
@@ -1,6 +1,6 @@
 cask 'font-iosevka-slab' do
-  version '2.2.1'
-  sha256 'a99e1f307dada2c31d9c24e5b12b141d327679d9e7f7068181859c9761900b82'
+  version '2.3.0'
+  sha256 'f02a2cd712e89fd91d9c6f29dc3edfd2ab8aa645c4fbbf2ef8e38e488bd0c4fc'
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-slab-#{version}.zip"
   appcast 'https://github.com/be5invis/Iosevka/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.