### PR TITLE
Update font-sudo to v0.40, install variable font only

### DIFF
--- a/Casks/font-sudo.rb
+++ b/Casks/font-sudo.rb
@@ -1,24 +1,11 @@
 cask 'font-sudo' do
-  version '0.39'
-  sha256 '8bb90bce533190b9d09c297ab959a4fba6764742bf2055364405b1e0ed16be67'
+  version '0.40'
+  sha256 'bd85aab2e8e9f0a903bd891fd4294e836cda6180ad926506f4907d1517d714b9'
 
   url "https://github.com/jenskutilek/sudo-font/releases/download/v#{version}/sudo.zip"
   appcast 'https://github.com/jenskutilek/sudo-font/releases.atom'
   name 'Sudo'
   homepage 'https://github.com/jenskutilek/sudo-font/'
 
-  font 'sudo/Sudo-Bold.ttf'
-  font 'sudo/Sudo-BoldItalic.ttf'
-  font 'sudo/Sudo-Italic.ttf'
-  font 'sudo/Sudo-Light.ttf'
-  font 'sudo/Sudo-LightItalic.ttf'
-  font 'sudo/Sudo-Medium.ttf'
-  font 'sudo/Sudo-MediumItalic.ttf'
-  font 'sudo/Sudo-Regular.ttf'
-  font 'sudo/Sudo-Thin.ttf'
-  font 'sudo/Sudo-ThinItalic.ttf'
-  font 'sudo/SudoGX-1131.ttf'
-  font 'sudo/SudoGX-1230.ttf'
-  font 'sudo/SudoGX-1238.ttf'
   font 'sudo/SudoVariable.ttf'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

_Cannot run `brew cask style --fix {{cask_file}}` because some gem dependencies fail to compile on my system. I can't be bothered to debug this right now, but it should be OK because there are only minor changes._

CC @vitorgalvao

Fixes #1875.