### PR TITLE
Update font-inter from 3.9 to 3.10

### DIFF
--- a/Casks/font-inter.rb
+++ b/Casks/font-inter.rb
@@ -1,6 +1,6 @@
 cask 'font-inter' do
-  version '3.9'
-  sha256 '445f71a2c6d0a64c11649533346ded15eb28c1be97b5866910f786da78ab4dbb'
+  version '3.10'
+  sha256 '53c4a2fce40bf79ee08d279c1993e9d918425a74f2ed9455350127e6047d7754'
 
   # github.com/rsms/inter was verified as official when first introduced to the cask
   url "https://github.com/rsms/inter/releases/download/v#{version}/Inter-#{version}.zip"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.