### PR TITLE
Update font-cascadia.rb from 1909.16 to 1910.04

### DIFF
--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,6 +1,6 @@
 cask 'font-cascadia' do
-  version '1909.16'
-  sha256 'c0485d313fbc40f9076e707ed0aa98c9e3f2649d8b30adff705cebf0a0dc1d93'
+  version '1910.04'
+  sha256 '044f2d1e854f976d0f9a639304d827718aa2b943707873bfff17575dda8f0551'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/Cascadia.ttf"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
