### PR TITLE
Update download url of ipafont v003.03 and ipaexfont v004.01

### DIFF
--- a/Casks/font-ipaexfont.rb
+++ b/Casks/font-ipaexfont.rb
@@ -2,7 +2,7 @@ cask 'font-ipaexfont' do
   version '004.01'
   sha256 'bcf8374ab3f9672c421120430dd19a51c99f5265cf06fc340d9a661ddfd7974b'
 
-  url "https://oscdl.ipa.go.jp/IPAexfont/IPAexfont#{version.no_dots}.zip"
+  url "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont#{version.no_dots}.zip"
   name 'IPAex Fonts'
   homepage 'https://ipafont.ipa.go.jp/'
 

--- a/Casks/font-ipafont.rb
+++ b/Casks/font-ipafont.rb
@@ -2,7 +2,7 @@ cask 'font-ipafont' do
   version '003.03'
   sha256 'f755ed79a4b8e715bed2f05a189172138aedf93db0f465b4e20c344a02766fe5'
 
-  url "https://ipafont.ipa.go.jp/old/ipafont/IPAfont#{version.no_dots}.php"
+  url "https://ipafont.ipa.go.jp/IPAfont/IPAfont#{version.no_dots}.zip"
   name 'IPA Fonts'
   homepage 'https://ipafont.ipa.go.jp/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
