### PR TITLE
Restore Antinoou 1.0.6

### DIFF
--- a/Casks/font-antinoou.rb
+++ b/Casks/font-antinoou.rb
@@ -1,0 +1,11 @@
+cask 'font-antinoou' do
+  version '1.0.6'
+  sha256 'd7f961ff2ab5b6c707e4f0a24e8302c7a61c2e2ab2e9880c94a8deb6f5aeff69'
+
+  url 'https://www.evertype.com/fonts/coptic/AntinoouFont.zip'
+  name 'Antinoou'
+  homepage 'https://www.evertype.com/fonts/coptic/'
+
+  font "AntinoouFont-#{version}/Antinoou.ttf"
+  font "AntinoouFont-#{version}/AntinoouItalic.ttf"
+end


### PR DESCRIPTION
This was removed in #1832 due to a small number of downloads. It's one of the few fonts, however, with Coptic support, and is created by an important contributor to Unicode (e.g. it is practically the only font available with U+2E35). Would you consider restoring it?

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
