### PR TITLE
Update font-cascadia from 1910.20 to 1911.21

### DIFF
--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,6 +1,6 @@
 cask 'font-cascadia' do
-  version '1911.20'
-  sha256 '2def0097704c114c07e346a91876e5447e8f930c3ad1606e102a8299541b8842'
+  version '1911.21'
+  sha256 'cf5b69933c568eac4231303a952ce57c1581dac10c6e73c70b763cf9ecaabed4'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/Cascadia.ttf"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
