### PR TITLE
Cascadia Code: new "Mono", "MonoPL" and "PL"

### DIFF
--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,0 +1,11 @@
+cask 'font-cascadia-mono-pl' do
+  version '1911.21'
+  sha256 'e39856b0547b2df704520260778ba94bde5fc38c4385fbac3cc9362f2a6ab877'
+
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaMonoPL.ttf"
+  appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
+  name 'Cascadia Mono PL'
+  homepage 'https://github.com/microsoft/cascadia-code'
+
+  font 'CascadiaMonoPL.ttf'
+end

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,0 +1,11 @@
+cask 'font-cascadia-mono' do
+  version '1911.21'
+  sha256 '00dd551dd2a91377f48d4361f715494cf394c053eae7ee550ced5f0db3a9706e'
+
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaMono.ttf"
+  appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
+  name 'Cascadia Mono'
+  homepage 'https://github.com/microsoft/cascadia-code'
+
+  font 'CascadiaMono.ttf'
+end

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -1,0 +1,11 @@
+cask 'font-cascadia-pl' do
+  version '1911.21'
+  sha256 '5b612e4e3bec453bab26299eac8330f7cc68b99d685ab86c01cdc54d5d6203e9'
+
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaPL.ttf"
+  appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
+  name 'Cascadia PL'
+  homepage 'https://github.com/microsoft/cascadia-code'
+
+  font 'CascadiaPL.ttf'
+end


### PR DESCRIPTION
Fixes #1915
Three different casks as there's no single zip distribution, but different downloads for each font variation.
Also, it makes sense to not bundle "regular", "mono" (no ligatures) and "pl" (powerline) versions as most users will ever only decide on a single one to use.


<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
