### PR TITLE
Fix paths in font-roboto-slab

### DIFF
--- a/Casks/font-roboto-slab.rb
+++ b/Casks/font-roboto-slab.rb
@@ -11,8 +11,8 @@ cask 'font-roboto-slab' do
 
   depends_on macos: '>= :sierra'
 
-  font 'RobotoSlab-Bold.ttf'
-  font 'RobotoSlab-Light.ttf'
-  font 'RobotoSlab-Regular.ttf'
-  font 'RobotoSlab-Thin.ttf'
+  font 'static/RobotoSlab-Bold.ttf'
+  font 'static/RobotoSlab-Light.ttf'
+  font 'static/RobotoSlab-Regular.ttf'
+  font 'static/RobotoSlab-Thin.ttf'
 end


### PR DESCRIPTION
It seems upstream has changed structure in repo so files are in a static/ directory, this commit addresses that.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version. _Version not relevant_
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
