### PR TITLE
Update font-firacode-nerd-font from 2.0.0 to 2.1.0

### DIFF
--- a/Casks/font-firacode-nerd-font.rb
+++ b/Casks/font-firacode-nerd-font.rb
@@ -1,15 +1,15 @@
 cask 'font-firacode-nerd-font' do
-  version '2.0.0'
-  sha256 '09894d24bf3d61493dba052187a9200497135a4b885cb837bcb637ad2e62070f'
+  version '2.1.0'
+  sha256 '21de9aa0edaa3fd2dc1d87fb9ecec0b67c9b3b18bd1998a19904158067fea7e7'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/FiraCode.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom'
-  name 'FuraCode Nerd Font (FiraCode)'
-  homepage 'https://github.com/ryanoasis/nerd-fonts'
+  name 'FiraCode Nerd Font (FiraCode)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode'
 
-  font 'Fura Code Bold Nerd Font Complete.otf'
-  font 'Fura Code Medium Nerd Font Complete.otf'
-  font 'Fura Code Retina Nerd Font Complete.otf'
-  font 'Fura Code Regular Nerd Font Complete.otf'
-  font 'Fura Code Light Nerd Font Complete.otf'
+  font 'Fira Code Bold Nerd Font Complete.otf'
+  font 'Fira Code Medium Nerd Font Complete.otf'
+  font 'Fira Code Retina Nerd Font Complete.otf'
+  font 'Fira Code Regular Nerd Font Complete.otf'
+  font 'Fira Code Light Nerd Font Complete.otf'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.