### PR TITLE
Add NoLoopK variant of Fantasque Sans Mono 1.8.0

### DIFF
--- a/Casks/font-fantasque-sans-mono-noloopk.rb
+++ b/Casks/font-fantasque-sans-mono-noloopk.rb
@@ -1,0 +1,14 @@
+cask 'font-fantasque-sans-mono-noloopk' do
+  version '1.8.0'
+  sha256 'f7bddc6f1e5a6e0830e332394b1ade52980c784dc4a383cdbee8c568ed0bf3c1'
+
+  url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono-NoLoopK.zip"
+  appcast 'https://github.com/belluzj/fantasque-sans/releases.atom'
+  name 'Fantasque Sans Mono NoLoopK'
+  homepage 'https://github.com/belluzj/fantasque-sans'
+
+  font 'OTF/FantasqueSansMono-Bold.otf'
+  font 'OTF/FantasqueSansMono-BoldItalic.otf'
+  font 'OTF/FantasqueSansMono-Italic.otf'
+  font 'OTF/FantasqueSansMono-Regular.otf'
+end


### PR DESCRIPTION
Added the variant of Fantasque Sans Mono that doesn't have the loop on the 'k'.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
