### PR TITLE
Add no ligature versions of fantasque sans mono (v1.7.2)

### DIFF
--- a/Casks/font-fantasque-sans-mono-noligatures.rb
+++ b/Casks/font-fantasque-sans-mono-noligatures.rb
@@ -1,0 +1,22 @@
+# Fantasque sans mono added ligature support in v1.8.0 (this was the only change made
+# in that version), so v1.7.2 is the latest version without ligatures. Designer/maintainer
+# said the next release (after v1.8.0) will contain an official no ligature version (see
+# https://github.com/belluzj/fantasque-sans/issues/64#issuecomment-555420273), so the url
+# will need to be changed to update to that future version. This all means that this font
+# shouldn't be updated to v1.8.0, and if its updated to a version after that, the url needs
+# to be changed to download the normal no ligature zip.
+
+cask 'font-fantasque-sans-mono-noligatures' do
+  version '1.7.2'
+  sha256 'f3c712d02b3f1f78a2ba1e5be95f1366e75f910b22b7b9242449b2bd43d1f194'
+
+  url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono-Normal.zip"
+  appcast 'https://github.com/belluzj/fantasque-sans/releases.atom'
+  name 'Fantasque Sans Mono NoLigatures'
+  homepage 'https://github.com/belluzj/fantasque-sans'
+
+  font 'OTF/FantasqueSansMono-Bold.otf'
+  font 'OTF/FantasqueSansMono-BoldItalic.otf'
+  font 'OTF/FantasqueSansMono-Italic.otf'
+  font 'OTF/FantasqueSansMono-Regular.otf'
+end

--- a/Casks/font-fantasque-sans-mono-noloopk-noligatures.rb
+++ b/Casks/font-fantasque-sans-mono-noloopk-noligatures.rb
@@ -1,0 +1,22 @@
+# Fantasque sans mono added ligature support in v1.8.0 (this was the only change made
+# in that version), so v1.7.2 is the latest version without ligatures. Designer/maintainer
+# said the next release (after v1.8.0) will contain an official no ligature version (see
+# https://github.com/belluzj/fantasque-sans/issues/64#issuecomment-555420273), so the url
+# will need to be changed to update to that future version. This all means that this font
+# shouldn't be updated to v1.8.0, and if its updated to a version after that, the url needs
+# to be changed to download the normal no ligature zip.
+
+cask 'font-fantasque-sans-mono-noloopk-noligatures' do
+  version '1.7.2'
+  sha256 '44344eac738a8f0193c8b9d7e0e5696c783d656b98da5fa4ba8e796587e053b2'
+
+  url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono-NoLoopK.zip"
+  appcast 'https://github.com/belluzj/fantasque-sans/releases.atom'
+  name 'Fantasque Sans Mono NoLoopK NoLigatures'
+  homepage 'https://github.com/belluzj/fantasque-sans'
+
+  font 'OTF/FantasqueSansMono-Bold.otf'
+  font 'OTF/FantasqueSansMono-BoldItalic.otf'
+  font 'OTF/FantasqueSansMono-Italic.otf'
+  font 'OTF/FantasqueSansMono-Regular.otf'
+end


### PR DESCRIPTION
Added the no ligature version of both the normal and noloopk variant of fantasque sans mono.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
