### PR TITLE
Update font-spleen from 1.6.0 to 1.7.0

### DIFF
--- a/Casks/font-spleen.rb
+++ b/Casks/font-spleen.rb
@@ -1,11 +1,11 @@
 cask 'font-spleen' do
-  version '1.6.0'
-  sha256 '58aa8266e87c337087716c4cfd03e4eba97a0426a25e0326fb681915c137bb15'
+  version '1.7.0'
+  sha256 '2a8768d5cd2f4be327ee66bd80f343edd9e31af7836c4a177dd85caac9289cd8'
 
   url "https://github.com/fcambus/spleen/releases/download/#{version}/spleen-#{version}.tar.gz"
   appcast 'https://github.com/fcambus/spleen/releases.atom'
   name 'Spleen'
   homepage 'https://github.com/fcambus/spleen'
 
-  font "spleen-#{version}/spleen-32x64.dfont"
+  font "spleen-#{version}/spleen-32x64.otf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.