### PR TITLE
Update font-jetbrains-mono from 1.0.3 to 1.0.4

### DIFF
--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -1,6 +1,6 @@
 cask 'font-jetbrains-mono' do
-  version '1.0.3'
-  sha256 'e357094992c4aff1e933354db198c6ffe2ee741bc4f3d9c071956c9e05b871ed'
+  version '1.0.4'
+  sha256 '737acc16715dbf911e833dd80fa27c49b2264c11800b0202f91b8745afa34a04'
 
   # github.com/JetBrains/JetBrainsMono was verified as official when first introduced to the cask
   url "https://github.com/JetBrains/JetBrainsMono/releases/download/v#{version}/JetBrainsMono-#{version}.zip"

--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -8,12 +8,20 @@ cask 'font-jetbrains-mono' do
   name 'JetBrains Mono'
   homepage 'https://www.jetbrains.com/lp/mono'
 
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-Bold-Italic.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-Bold.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-ExtraBold-Italic.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-ExtraBold.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-Italic.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-Medium-Italic.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-Medium.ttf"
-  font "JetBrainsMono-#{version}-Source/ttf/JetBrainsMono-Regular.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Bold-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Bold.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-ExtraBold-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-ExtraBold.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Medium-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Medium.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Regular.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Regular.ttf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.