### PR TITLE
Add font-open-huninn 1.0

### DIFF
--- a/Casks/font-jf-open-huninn.rb
+++ b/Casks/font-jf-open-huninn.rb
@@ -1,12 +1,12 @@
 cask 'font-jf-open-huninn' do
   version '1.0'
-  sha256 'a74427f19405b25d95135b673aff81565e833b7f3165c43f283a010ff736ba07'
+  sha256 '20b18c056608ec078d22f1677b52fd1b616def1512f17be5d37831f09f517d5d'
 
-  # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
-  url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'
+  # raw.githubusercontent.com/justfont/open-huninn-font was verified as official when first introduced to the cask
+  url "https://raw.githubusercontent.com/justfont/open-huninn-font/master/font/jf-openhuninn-#{version}.ttf"
   name 'jf open huninn'
   name 'jf open 粉圓'
   homepage 'https://justfont.com/huninn/'
 
-  font "open-huninn-font-master/font/jf-openhuninn-#{version}.ttf"
+  font "jf-openhuninn-#{version}.ttf"
 end

--- a/Casks/font-jf-open-huninn.rb
+++ b/Casks/font-jf-open-huninn.rb
@@ -5,6 +5,7 @@ cask 'font-jf-open-huninn' do
   # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
   url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'
   name 'jf open huninn'
+  name 'jf open 粉圓'
   homepage 'https://justfont.com/huninn/'
 
   font "open-huninn-font-master/font/jf-openhuninn-#{version}.ttf"

--- a/Casks/font-jf-open-huninn.rb
+++ b/Casks/font-jf-open-huninn.rb
@@ -1,11 +1,11 @@
-cask 'font-open-huninn' do
+cask 'font-jf-open-huninn' do
   version '1.0'
   sha256 '8b0d0e8fd396a763371ae21bcf7140926e7837d5851d108108b858de42c9b5e2'
 
   # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
   url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'
-  name 'jf-openhuninn-1.0'
+  name 'jf open huninn'
   homepage 'https://justfont.com/huninn/'
 
-  font 'open-huninn-font-master/font/jf-openhuninn-1.0.ttf'
+  font "open-huninn-font-master/font/jf-openhuninn-#{version}.ttf"
 end

--- a/Casks/font-jf-open-huninn.rb
+++ b/Casks/font-jf-open-huninn.rb
@@ -1,6 +1,6 @@
 cask 'font-jf-open-huninn' do
   version '1.0'
-  sha256 :no_check
+  sha256 'a74427f19405b25d95135b673aff81565e833b7f3165c43f283a010ff736ba07'
 
   # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
   url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'

--- a/Casks/font-jf-open-huninn.rb
+++ b/Casks/font-jf-open-huninn.rb
@@ -1,6 +1,6 @@
 cask 'font-jf-open-huninn' do
   version '1.0'
-  sha256 '8b0d0e8fd396a763371ae21bcf7140926e7837d5851d108108b858de42c9b5e2'
+  sha256 :no_check
 
   # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
   url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'

--- a/Casks/font-open-huninn.rb
+++ b/Casks/font-open-huninn.rb
@@ -1,0 +1,11 @@
+cask 'font-open-huninn' do
+  version '1.0'
+  sha256 '20b18c056608ec078d22f1677b52fd1b616def1512f17be5d37831f09f517d5d'
+
+  # justfont.com/huninn was verified as the official when first introduced to the cask
+  url 'https://raw.githubusercontent.com/justfont/open-huninn-font/master/font/jf-openhuninn-1.0.ttf'
+  name 'jf-openhuninn-1.0'
+  homepage 'https://justfont.com/huninn/'
+
+  font 'jf-openhuninn-1.0.ttf'
+end

--- a/Casks/font-open-huninn.rb
+++ b/Casks/font-open-huninn.rb
@@ -1,11 +1,12 @@
 cask 'font-open-huninn' do
   version '1.0'
-  sha256 '20b18c056608ec078d22f1677b52fd1b616def1512f17be5d37831f09f517d5d'
+  sha256 '8b0d0e8fd396a763371ae21bcf7140926e7837d5851d108108b858de42c9b5e2'
 
-  # justfont.com/huninn was verified as the official when first introduced to the cask
-  url 'https://raw.githubusercontent.com/justfont/open-huninn-font/master/font/jf-openhuninn-1.0.ttf'
+  # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
+  url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'
+
   name 'jf-openhuninn-1.0'
   homepage 'https://justfont.com/huninn/'
 
-  font 'jf-openhuninn-1.0.ttf'
+  font 'open-huninn-font-master/font/jf-openhuninn-1.0.ttf'
 end

--- a/Casks/font-open-huninn.rb
+++ b/Casks/font-open-huninn.rb
@@ -4,7 +4,6 @@ cask 'font-open-huninn' do
 
   # codeload.github.com/justfont/open-huninn-font was verified as official when first introduced to the cask
   url 'https://codeload.github.com/justfont/open-huninn-font/zip/master'
-
   name 'jf-openhuninn-1.0'
   homepage 'https://justfont.com/huninn/'
 


### PR DESCRIPTION
Hi, open-huninn is a new font that is just released under SIL Open Font License 1.1.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
