### PR TITLE
jetbrains-mono v1.0.4: removed NL version (no ligatures)

### DIFF
--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -9,19 +9,11 @@ cask 'font-jetbrains-mono' do
   homepage 'https://www.jetbrains.com/lp/mono'
 
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Bold-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold-Italic.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Bold.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-ExtraBold-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold-Italic.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-ExtraBold.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Italic.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Medium-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium-Italic.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Medium.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium.ttf"
   font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Regular.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Regular.ttf"
 end


### PR DESCRIPTION
Removed the "no ligatures" version from the jetbrains-mono v1.0.4. No ligatures alternative is going to be added in separate cask.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
