### PR TITLE
Created font jetbrains-mono-nl v1.0.4 #1

### DIFF
--- a/font-jetbrains-mono-nl.rb
+++ b/font-jetbrains-mono-nl.rb
@@ -1,0 +1,19 @@
+cask 'font-jetbrains-mono-nl' do
+  version '1.0.4'
+  sha256 '737acc16715dbf911e833dd80fa27c49b2264c11800b0202f91b8745afa34a04'
+
+  # github.com/JetBrains/JetBrainsMono was verified as official when first introduced to the cask
+  url "https://github.com/JetBrains/JetBrainsMono/releases/download/v#{version}/JetBrainsMono-#{version}.zip"
+  appcast 'https://github.com/JetBrains/JetBrainsMono/releases.atom'
+  name 'JetBrains Mono'
+  homepage 'https://www.jetbrains.com/lp/mono'
+
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium-Italic.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium.ttf"
+  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Regular.ttf"
+end


### PR DESCRIPTION
This cask contains a spinoff of JetBrains Mono NL font v1.0.4 (see https://github.com/JetBrains/JetBrainsMono/issues/19 for more info)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask