### PR TITLE
Adds fonts for Balsamiq Sans

### DIFF
--- a/Casks/font-balsamiq-sans.rb
+++ b/Casks/font-balsamiq-sans.rb
@@ -1,4 +1,4 @@
-cask 'font-balsamiqsans' do
+cask 'font-balsamiq-sans' do
   version :latest
   sha256 :no_check
 

--- a/Casks/font-balsamiqsans.rb
+++ b/Casks/font-balsamiqsans.rb
@@ -1,0 +1,14 @@
+cask 'font-balsamiqsans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/balsamiq/balsamiqsans was verified as official when first introduced to the cask
+  url 'https://github.com/balsamiq/balsamiqsans/archive/master.zip'
+  name 'Balsamiq Sans'
+  homepage 'https://balsamiq.com/givingback/opensource/font/'
+
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansBold.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansBoldItalic.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansItalic.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansRegular.ttf'
+end


### PR DESCRIPTION
Hello 👋

This PR adds [Balsamiq Sans](https://balsamiq.com/givingback/opensource/font/). 

The font is licensed under the _SIL Open Font License_ (OFL), as listed here: [scripts.sil.org](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL).


- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

The Balsamiq Fonts [repository](https://github.com/balsamiq/balsamiqsans/releases) does not have any tagged / released versions, so I went with `:latest`.  (Happy to change this to a commit-ish, if that is more helpful)

Additionally, if **adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked the cask was not [already refused].
- [X] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask

