### PR TITLE
Update font-sudo from 0.41 to 0.42

### DIFF
--- a/Casks/font-sudo.rb
+++ b/Casks/font-sudo.rb
@@ -1,6 +1,6 @@
 cask 'font-sudo' do
-  version '0.41'
-  sha256 'ca1c89691a5ee96cbd0c4b0df911109b3230177efb9f1c6d6763014ed0ffdcaf'
+  version '0.42'
+  sha256 'ae7979cce3f69160293416089b91fe9f5f20bd25a288099ba61f067930df3d64'
 
   url "https://github.com/jenskutilek/sudo-font/releases/download/v#{version}/sudo.zip"
   appcast 'https://github.com/jenskutilek/sudo-font/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.