### PR TITLE
font-gnu-unifont 13.0.01

### DIFF
--- a/Casks/font-gnu-unifont.rb
+++ b/Casks/font-gnu-unifont.rb
@@ -1,11 +1,15 @@
 cask 'font-gnu-unifont' do
-  version '10.0.06'
-  sha256 '669a9764fb640c832a8ebfbd2c351be744b55c6f65b40f1fb203144309659ac0'
+  version '13.0.01'
+  sha256 '8b486450b2bd1dc9357ceca096faf493d13f7e582f29984e46552ca8faa87feb'
 
   # ftpmirror.gnu.org/unifont was verified as official when first introduced to the cask
-  url "https://ftpmirror.gnu.org/unifont/unifont-#{version}/unifont-#{version}.ttf"
+  url "https://ftpmirror.gnu.org/unifont/unifont-#{version}/unifont-#{version}.tar.gz"
   name 'GNU Unifont'
   homepage 'http://unifoundry.com/unifont.html'
 
-  font "unifont-#{version}.ttf"
+  font "unifont-#{version}/font/precompiled/unifont-#{version}.ttf"
+  font "unifont-#{version}/font/precompiled/unifont_upper-#{version}.ttf"
+  font "unifont-#{version}/font/precompiled/unifont_sample-#{version}.ttf"
+  font "unifont-#{version}/font/precompiled/unifont_jp-#{version}.ttf"
+  font "unifont-#{version}/font/precompiled/unifont_csur-#{version}.ttf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download font-gnu-unifont` is error-free.
- [x] `brew cask style --fix font-gnu-unifont` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [**a stable version**](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
