### PR TITLE
Revert "Update font-meslo-nerd-font from 2.0.0 to 2.1.0"

### DIFF
--- a/Casks/font-meslo-nerd-font.rb
+++ b/Casks/font-meslo-nerd-font.rb
@@ -1,16 +1,16 @@
 cask 'font-meslo-nerd-font' do
-  version '2.1.0'
-  sha256 'f0630f93b2f8c27b0cda8c4a2bae2b7a67bdd70786500e109f38c3a9b145f523'
+  version '2.0.0'
+  sha256 '350ff0b1061ca0d1e933c59861d6421ebb2667d494875fcb1821d3df44f08476'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Meslo.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom'
   name 'Meslo Nerd Font (Meslo)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 
-  font 'Meslo LG M Regular Nerd Font Complete.ttf'
-  font 'Meslo LG L Regular Nerd Font Complete.ttf'
-  font 'Meslo LG S Regular Nerd Font Complete.ttf'
-  font 'Meslo LG L DZ Regular Nerd Font Complete.ttf'
-  font 'Meslo LG M DZ Regular Nerd Font Complete.ttf'
-  font 'Meslo LG S DZ Regular Nerd Font Complete.ttf'
+  font 'Meslo LG M Regular Nerd Font Complete.otf'
+  font 'Meslo LG L Regular Nerd Font Complete.otf'
+  font 'Meslo LG S Regular Nerd Font Complete.otf'
+  font 'Meslo LG L DZ Regular Nerd Font Complete.otf'
+  font 'Meslo LG M DZ Regular Nerd Font Complete.otf'
+  font 'Meslo LG S DZ Regular Nerd Font Complete.otf'
 end


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask-fonts#2003 in favour of https://github.com/Homebrew/homebrew-cask-fonts/pull/1999.