### PR TITLE
Update font-3270 to version 2.0.4

### DIFF
--- a/Casks/font-3270.rb
+++ b/Casks/font-3270.rb
@@ -1,13 +1,16 @@
 cask 'font-3270' do
-  version '1.2.23,d250fd9'
-  sha256 '9cf7235088b3afe7827b24fec534a569b5cab15c26e0b5b6956cc2af0db837b6'
+  version '2.0.4,ece94f6'
+  sha256 'd5755c4774eb5ab81b8284d53021930ec55b191ab977f14d27b25c6f33358963'
 
   url "https://github.com/rbanffy/3270font/releases/download/v#{version.before_comma}/3270_fonts_#{version.after_comma}.zip"
   appcast 'https://github.com/rbanffy/3270font/releases.atom'
   name 'IBM 3270'
   homepage 'https://github.com/rbanffy/3270font'
 
-  font '3270Medium.otf'
-  font '3270Narrow.otf'
-  font '3270SemiNarrow.otf'
+  font '3270-Regular.otf'
+  font '3270-Regular.ttf'
+  font '3270Condensed-Regular.otf'
+  font '3270Condensed-Regular.ttf'
+  font '3270SemiCondensed-Regular.otf'
+  font '3270SemiCondensed-Regular.ttf'
 end


### PR DESCRIPTION
This update brings a lot of fixes in relation to the previous release (cyrillic support, table and metadata fixes thanks to Google Fonts validation tools and Unicode 13's Symbols for Legacy Computing, that adds full set of 2x3 videotext mosaic blocks, TRS-80, PETSCII and ATASCII)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
