### PR TITLE
Rename DejaVu fonts

### DIFF
--- a/Casks/font-dejavu.rb
+++ b/Casks/font-dejavu.rb
@@ -1,4 +1,4 @@
-cask 'font-dejavu-sans' do
+cask 'font-dejavu' do
   version '2.37'
   sha256 '7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a'
 


### PR DESCRIPTION
Cask includes sans, serif, and mono versions – not only the sans.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
