### PR TITLE
updates filenames to match upstream update

### DIFF
--- a/Casks/font-balsamiq-sans.rb
+++ b/Casks/font-balsamiq-sans.rb
@@ -7,7 +7,7 @@ cask 'font-balsamiq-sans' do
   name 'Balsamiq Sans'
   homepage 'https://balsamiq.com/givingback/opensource/font/'
 
-  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansBold.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-Bold.ttf'
   font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-BoldItalic.ttf'
   font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-Italic.ttf'
   font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-Regular.ttf'

--- a/Casks/font-balsamiq-sans.rb
+++ b/Casks/font-balsamiq-sans.rb
@@ -8,7 +8,7 @@ cask 'font-balsamiq-sans' do
   homepage 'https://balsamiq.com/givingback/opensource/font/'
 
   font 'balsamiqsans-master/fonts/ttf/BalsamiqSansBold.ttf'
-  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansBoldItalic.ttf'
-  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansItalic.ttf'
-  font 'balsamiqsans-master/fonts/ttf/BalsamiqSansRegular.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-BoldItalic.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-Italic.ttf'
+  font 'balsamiqsans-master/fonts/ttf/BalsamiqSans-Regular.ttf'
 end


### PR DESCRIPTION
https://github.com/balsamiq/balsamiqsans/tree/master/fonts/ttf was recently updated with new file names for the four font weights.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
