### PR TITLE
Update font-fira-code from 3 to 3.1

### DIFF
--- a/Casks/font-fira-code.rb
+++ b/Casks/font-fira-code.rb
@@ -1,6 +1,6 @@
 cask 'font-fira-code' do
-  version '3'
-  sha256 '043fa00e002704aec6f8b5e1908faf099f9477160d00ad0260a8103329c3981b'
+  version '3.1'
+  sha256 'cbcabd2c412ee4c3fec4688be8387de18a33bb77bc5c5988e9fd9293a0b9dbb7'
 
   url "https://github.com/tonsky/FiraCode/releases/download/#{version}/FiraCode_#{version}.zip"
   appcast 'https://github.com/tonsky/FiraCode/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.