### PR TITLE
Fix installation of font-inconsolata

### DIFF
--- a/Casks/font-inconsolata.rb
+++ b/Casks/font-inconsolata.rb
@@ -11,6 +11,5 @@ cask 'font-inconsolata' do
 
   depends_on macos: '>= :sierra'
 
-  font 'Inconsolata-Regular.ttf'
-  font 'Inconsolata-Bold.ttf'
+  font 'Inconsolata[wdth,wght].ttf'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
