### PR TITLE
Update Roboto Condensed URL after Roboto was updated to v3

### DIFF
--- a/Casks/font-roboto-condensed.rb
+++ b/Casks/font-roboto-condensed.rb
@@ -3,7 +3,7 @@ cask 'font-roboto-condensed' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/apache/robotocondensed',
+  url 'https://github.com/google/fonts/trunk/ofl/roboto/static',
       using:      :svn,
       trust_cert: true
   name 'Roboto Condensed'


### PR DESCRIPTION
In response to https://github.com/google/fonts/pull/2414/files.

Sorry, it seems that my previous PR #2018 got some merge conflicts, so I think this PR should resolve that. The code is the same, just with the branch rebased on top of `master`.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
