### PR TITLE
Update font-cozette from 1.7.0 to 1.8.0

### DIFF
--- a/Casks/font-cozette.rb
+++ b/Casks/font-cozette.rb
@@ -1,6 +1,6 @@
 cask 'font-cozette' do
-  version '1.7.0'
-  sha256 '325208db6555726a07a0217ef409fb20efd2d765b83bb0e4273a6d06494a69be'
+  version '1.8.0'
+  sha256 'c6d153c8d7989ff8f7d0d3206cdc5e6863e376b774b181744c477ad7aa5710b2'
 
   url "https://github.com/slavfox/Cozette/releases/download/v.#{version}/CozetteVector.dfont"
   appcast 'https://github.com/slavfox/Cozette/releases.atom'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.