### PR TITLE
Update font Work Sans to use master version

### DIFF
--- a/Casks/font-work-sans.rb
+++ b/Casks/font-work-sans.rb
@@ -4,7 +4,6 @@ cask 'font-work-sans' do
 
   # github.com/weiweihuanghuang/Work-Sans/ was verified as official when first introduced to the cask
   url 'https://github.com/weiweihuanghuang/Work-Sans/archive/master.zip'
-  appcast 'https://github.com/weiweihuanghuang/Work-Sans/releases.atom'
   name 'Work Sans'
   homepage 'https://weiweihuanghuang.github.io/Work-Sans/'
 

--- a/Casks/font-work-sans.rb
+++ b/Casks/font-work-sans.rb
@@ -1,20 +1,29 @@
 cask 'font-work-sans' do
-  version '1.6'
-  sha256 '247bd98900d52fc1016098449dd906472a2c85e956b62736f04929d8922f7fcf'
+  version :latest
+  sha256 :no_check
 
   # github.com/weiweihuanghuang/Work-Sans/ was verified as official when first introduced to the cask
-  url "https://github.com/weiweihuanghuang/Work-Sans/archive/v#{version}.zip"
+  url 'https://github.com/weiweihuanghuang/Work-Sans/archive/master.zip'
   appcast 'https://github.com/weiweihuanghuang/Work-Sans/releases.atom'
   name 'Work Sans'
   homepage 'https://weiweihuanghuang.github.io/Work-Sans/'
 
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-Black.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-Bold.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-ExtraBold.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-ExtraLight.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-Light.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-Medium.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-Regular.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-SemiBold.otf"
-  font "Work-Sans-#{version}/fonts/desktop/WorkSans-Thin.otf"
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Black.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-BlackItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Bold.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-BoldItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-ExtraBold.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-ExtraBoldItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-ExtraLight.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-ExtraLightItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Italic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Light.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-LightItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Medium.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-MediumItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Regular.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-SemiBold.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-SemiBoldItalic.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-Thin.ttf'
+  font 'Work-Sans-master/fonts/static/TTF/WorkSans-ThinItalic.ttf'
 end


### PR DESCRIPTION
After version 1.6, no new releases have been made, although development has continued (with the addition of italics as a major improvement). This PR changes the formula to fetch the latest version from the `master` branch, disregarding the version numbering. I have [asked](https://github.com/weiweihuanghuang/Work-Sans/issues/48) the maintainer to start making versioned releases again. When they respond, I will change the formula to use versions again.

**Question:** is it still relevant to have an `appcast` when we do not use the info?

**Question:** although it is not specifically released as a new version, the font files do contain version numbers (the latest is 2.009). Is it preferably to make this explicit by changing `version :latest` to `version '2.009'`, and add the appriate `sha256`?

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

----

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
