### PR TITLE
 Update font-cascadia variants from 1911.21 to 2004.30

### DIFF
--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia-mono-pl' do
-  version '1911.21'
-  sha256 'e39856b0547b2df704520260778ba94bde5fc38c4385fbac3cc9362f2a6ab877'
+  version '2004.30'
+  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaMonoPL.ttf"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono PL'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'CascadiaMonoPL.ttf'
+  font 'otf/CascadiaMonoPL.otf'
 end

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia-mono' do
-  version '1911.21'
-  sha256 '00dd551dd2a91377f48d4361f715494cf394c053eae7ee550ced5f0db3a9706e'
+  version '2004.30'
+  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaMono.ttf"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'CascadiaMono.ttf'
+  font 'otf/CascadiaMono.otf'
 end

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia-pl' do
-  version '1911.21'
-  sha256 '5b612e4e3bec453bab26299eac8330f7cc68b99d685ab86c01cdc54d5d6203e9'
+  version '2004.30'
+  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaPL.ttf"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia PL'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'CascadiaPL.ttf'
+  font 'otf/CascadiaCodePL.otf'
 end

--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia' do
-  version '1911.21'
-  sha256 'cf5b69933c568eac4231303a952ce57c1581dac10c6e73c70b763cf9ecaabed4'
+  version '2004.30'
+  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/Cascadia.ttf"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'Cascadia.ttf'
+  font 'otf/CascadiaCode.otf'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
