### PR TITLE
Update font-inconsolata.rb

### DIFF
--- a/Casks/font-inconsolata.rb
+++ b/Casks/font-inconsolata.rb
@@ -3,7 +3,7 @@ cask 'font-inconsolata' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/ofl/inconsolata',
+  url 'https://github.com/google/fonts/tree/master/ofl/inconsolata',
       using:      :svn,
       trust_cert: true
   name 'Inconsolata'

--- a/Casks/font-inconsolata.rb
+++ b/Casks/font-inconsolata.rb
@@ -3,7 +3,7 @@ cask 'font-inconsolata' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/blob/master/ofl/inconsolata',
+  url 'https://github.com/google/fonts/blob/master/ofl/inconsolata/Inconsolata%5Bwdth%2Cwght%5D.ttf',
       using:      :svn,
       trust_cert: true
   name 'Inconsolata'

--- a/Casks/font-inconsolata.rb
+++ b/Casks/font-inconsolata.rb
@@ -3,7 +3,7 @@ cask 'font-inconsolata' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/tree/master/ofl/inconsolata',
+  url 'https://github.com/google/fonts/blob/master/ofl/inconsolata/Inconsolata%5Bwdth%2Cwght%5D.ttf',
       using:      :svn,
       trust_cert: true
   name 'Inconsolata'

--- a/Casks/font-inconsolata.rb
+++ b/Casks/font-inconsolata.rb
@@ -3,7 +3,7 @@ cask 'font-inconsolata' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/blob/master/ofl/inconsolata/Inconsolata%5Bwdth%2Cwght%5D.ttf',
+  url 'https://github.com/google/fonts/blob/master/ofl/inconsolata',
       using:      :svn,
       trust_cert: true
   name 'Inconsolata'


### PR DESCRIPTION
The old link is broken: https://github.com/google/fonts/trunk/ofl/inconsolata is not valid anymore.
Has to become: https://github.com/google/fonts/tree/master/ofl/inconsolata

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not [already refused].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
