### PR TITLE
Update font-cascadia variants from 2004.30 to 2005.15

### DIFF
--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,6 +1,6 @@
 cask 'font-cascadia-mono-pl' do
-  version '2004.30'
-  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
+  version '2005.15'
+  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,6 +1,6 @@
 cask 'font-cascadia-mono' do
-  version '2004.30'
-  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
+  version '2005.15'
+  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -1,6 +1,6 @@
 cask 'font-cascadia-pl' do
-  version '2004.30'
-  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
+  version '2005.15'
+  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'

--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,6 +1,6 @@
 cask 'font-cascadia' do
-  version '2004.30'
-  sha256 'e240fcf61260bd3d6bc95f75336717fa5312a7bff312edbcb4dfc377825e7faf'
+  version '2005.15'
+  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).


[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask-fonts/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
