### PR TITLE
Update font-fira-code from 3 to 4

### DIFF
--- a/Casks/font-fira-code.rb
+++ b/Casks/font-fira-code.rb
@@ -1,8 +1,8 @@
 cask 'font-fira-code' do
-  version '3.1'
-  sha256 'cbcabd2c412ee4c3fec4688be8387de18a33bb77bc5c5988e9fd9293a0b9dbb7'
+  version '4'
+  sha256 '46ed45d1a793a56e13d31ed10fb7e09f5277731953a0d9522915644fc59086d8'
 
-  url "https://github.com/tonsky/FiraCode/releases/download/#{version}/FiraCode_#{version}.zip"
+  url "https://github.com/tonsky/FiraCode/releases/download/#{version}/Fira_Code_v#{version}.zip"
   appcast 'https://github.com/tonsky/FiraCode/releases.atom'
   name 'Fira Code'
   homepage 'https://github.com/tonsky/FiraCode'
@@ -12,4 +12,5 @@ cask 'font-fira-code' do
   font 'otf/FiraCode-Medium.otf'
   font 'otf/FiraCode-Regular.otf'
   font 'otf/FiraCode-Retina.otf'
+  font 'otf/FiraCode-SemiBold.otf'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

- version bump
- adjusted URL naming scheme
- added missing SemiBold weight introduced since version 3
