### PR TITLE
iosevka 3.0.1

### DIFF
--- a/Casks/font-iosevka-slab.rb
+++ b/Casks/font-iosevka-slab.rb
@@ -1,19 +1,19 @@
 cask 'font-iosevka-slab' do
-  version '3.0.0'
-  sha256 '0f1cc938a3d63d52ca7f72472fce1f9a37be27ae5cd58cf4c5167febd864e783'
+  version '3.0.1'
+  sha256 '25fdff0897aec4b855ee84dfcf7bcbd38cae89aec1779c3231f45e5782565981'
 
-  url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/pkg-iosevka-slab-#{version}.zip"
+  url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-slab-#{version}.zip"
   appcast 'https://github.com/be5invis/Iosevka/releases.atom'
   name 'Iosevka Slab'
   homepage 'https://github.com/be5invis/Iosevka/'
 
-  font 'ttc/iosevka-slab-bold.ttc'
-  font 'ttc/iosevka-slab-extrabold.ttc'
-  font 'ttc/iosevka-slab-extralight.ttc'
-  font 'ttc/iosevka-slab-heavy.ttc'
-  font 'ttc/iosevka-slab-light.ttc'
-  font 'ttc/iosevka-slab-medium.ttc'
-  font 'ttc/iosevka-slab-regular.ttc'
-  font 'ttc/iosevka-slab-semibold.ttc'
-  font 'ttc/iosevka-slab-thin.ttc'
+  font 'iosevka-slab-bold.ttc'
+  font 'iosevka-slab-extrabold.ttc'
+  font 'iosevka-slab-extralight.ttc'
+  font 'iosevka-slab-heavy.ttc'
+  font 'iosevka-slab-light.ttc'
+  font 'iosevka-slab-medium.ttc'
+  font 'iosevka-slab-regular.ttc'
+  font 'iosevka-slab-semibold.ttc'
+  font 'iosevka-slab-thin.ttc'
 end

--- a/Casks/font-iosevka.rb
+++ b/Casks/font-iosevka.rb
@@ -1,19 +1,19 @@
 cask 'font-iosevka' do
-  version '3.0.0'
-  sha256 '2339a51fd9270d788e13e8e21c357d96983a042c3175aafcc8dce0ceaa4ae52b'
+  version '3.0.1'
+  sha256 '5e66198c71f5e4b6acb383faaf250af2251465342163b2d8ee2cb154995d844f'
 
-  url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/pkg-iosevka-#{version}.zip"
+  url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-#{version}.zip"
   appcast 'https://github.com/be5invis/Iosevka/releases.atom'
   name 'Iosevka'
   homepage 'https://github.com/be5invis/Iosevka/'
 
-  font 'ttc/iosevka-bold.ttc'
-  font 'ttc/iosevka-extrabold.ttc'
-  font 'ttc/iosevka-extralight.ttc'
-  font 'ttc/iosevka-heavy.ttc'
-  font 'ttc/iosevka-light.ttc'
-  font 'ttc/iosevka-medium.ttc'
-  font 'ttc/iosevka-regular.ttc'
-  font 'ttc/iosevka-semibold.ttc'
-  font 'ttc/iosevka-thin.ttc'
+  font 'iosevka-bold.ttc'
+  font 'iosevka-extrabold.ttc'
+  font 'iosevka-extralight.ttc'
+  font 'iosevka-heavy.ttc'
+  font 'iosevka-light.ttc'
+  font 'iosevka-medium.ttc'
+  font 'iosevka-regular.ttc'
+  font 'iosevka-semibold.ttc'
+  font 'iosevka-thin.ttc'
 end


### PR DESCRIPTION
A few minutes after #2043 was merged, iosevka 3.0.1 was released. There's also now an artifact that just contains TTC files, which is a smaller download.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).