### PR TITLE
Fix path to Roboto Mono font files

### DIFF
--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -3,7 +3,7 @@ cask 'font-roboto-mono' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/apache/robotomono',
+  url 'https://github.com/google/fonts/trunk/apache/robotomono/static',
       using:      :svn,
       trust_cert: true
   name 'Roboto Mono'

--- a/Casks/font-roboto-slab.rb
+++ b/Casks/font-roboto-slab.rb
@@ -3,7 +3,7 @@ cask 'font-roboto-slab' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/apache/robotoslab',
+  url 'https://github.com/google/fonts/trunk/apache/robotoslab/static',
       using:      :svn,
       trust_cert: true
   name 'Roboto Slab'
@@ -11,8 +11,8 @@ cask 'font-roboto-slab' do
 
   depends_on macos: '>= :sierra'
 
-  font 'static/RobotoSlab-Bold.ttf'
-  font 'static/RobotoSlab-Light.ttf'
-  font 'static/RobotoSlab-Regular.ttf'
-  font 'static/RobotoSlab-Thin.ttf'
+  font 'RobotoSlab-Bold.ttf'
+  font 'RobotoSlab-Light.ttf'
+  font 'RobotoSlab-Regular.ttf'
+  font 'RobotoSlab-Thin.ttf'
 end


### PR DESCRIPTION
These font files recently moved into a new subdirectory named "static" in https://github.com/google/fonts/pull/2481, which matches the structure in Roboto (Regular), Condensed, and Slab.

Also changed the Slab formula to match the style of the other formulae.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
