### PR TITLE
fix path for Roboto Mono

### DIFF
--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -4,7 +4,6 @@ cask 'font-roboto-mono' do
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
   url 'https://github.com/google/fonts/tree/master/apache/robotomono/static'
-  
   name 'Roboto Mono'
   homepage 'https://www.google.com/fonts/specimen/Roboto%20Mono'
 

--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -3,20 +3,20 @@ cask 'font-roboto-mono' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/tree/master/apache/robotomono/static'
+  url 'https://github.com/google/fonts/tree/master/apache/robotomono'
   name 'Roboto Mono'
   homepage 'https://www.google.com/fonts/specimen/Roboto%20Mono'
 
   depends_on macos: '>= :sierra'
 
-  font 'RobotoMono-Bold.ttf'
-  font 'RobotoMono-BoldItalic.ttf'
-  font 'RobotoMono-Italic.ttf'
-  font 'RobotoMono-Light.ttf'
-  font 'RobotoMono-LightItalic.ttf'
-  font 'RobotoMono-Medium.ttf'
-  font 'RobotoMono-MediumItalic.ttf'
-  font 'RobotoMono-Regular.ttf'
-  font 'RobotoMono-Thin.ttf'
-  font 'RobotoMono-ThinItalic.ttf'
+  font 'static/RobotoMono-Bold.ttf'
+  font 'static/RobotoMono-BoldItalic.ttf'
+  font 'static/RobotoMono-Italic.ttf'
+  font 'static/RobotoMono-Light.ttf'
+  font 'static/RobotoMono-LightItalic.ttf'
+  font 'static/RobotoMono-Medium.ttf'
+  font 'static/RobotoMono-MediumItalic.ttf'
+  font 'static/RobotoMono-Regular.ttf'
+  font 'static/RobotoMono-Thin.ttf'
+  font 'static/RobotoMono-ThinItalic.ttf'
 end

--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -3,7 +3,7 @@ cask 'font-roboto-mono' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/apache/robotomono/static',
+  url 'https://github.com/google/fonts/tree/master/apache/robotomono/static',
       using:      :svn,
       trust_cert: true
   name 'Roboto Mono'

--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -3,9 +3,8 @@ cask 'font-roboto-mono' do
   sha256 :no_check
 
   # github.com/google/fonts/ was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/tree/master/apache/robotomono/static',
-      using:      :svn,
-      trust_cert: true
+  url 'https://github.com/google/fonts/tree/master/apache/robotomono/static'
+  
   name 'Roboto Mono'
   homepage 'https://www.google.com/fonts/specimen/Roboto%20Mono'
 


### PR DESCRIPTION
hope i'm not fucking anything up. but the previous path doesn't exist and make the cask hangs.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
