### PR TITLE
Update font-liberation

### DIFF
--- a/Casks/font-liberation.rb
+++ b/Casks/font-liberation.rb
@@ -7,16 +7,16 @@ cask 'font-liberation' do
   name 'Liberation Sans'
   homepage 'https://github.com/liberationfonts/liberation-fonts'
 
-  font "liberation-fonts-ttf-#{version}/LiberationMono-Bold.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationMono-BoldItalic.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationMono-Italic.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationMono-Regular.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSans-Bold.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSans-BoldItalic.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSans-Italic.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSans-Regular.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSerif-Bold.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSerif-BoldItalic.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSerif-Italic.ttf"
-  font "liberation-fonts-ttf-#{version}/LiberationSerif-Regular.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-Bold.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-BoldItalic.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-Italic.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-Regular.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSans-Bold.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSans-BoldItalic.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSans-Italic.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSans-Regular.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSerif-Bold.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSerif-BoldItalic.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSerif-Italic.ttf"
+  font "liberation-fonts-ttf-#{version.before_comma}/LiberationSerif-Regular.ttf"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Fix a bug introduced in #2084. Now `version.before_comma` is used in font stanza as well.