### PR TITLE
Update font-liberation

### DIFF
--- a/Casks/font-liberation.rb
+++ b/Casks/font-liberation.rb
@@ -4,7 +4,7 @@ cask 'font-liberation' do
 
   url "https://github.com/liberationfonts/liberation-fonts/files/#{version.after_comma}/liberation-fonts-ttf-#{version.before_comma}.tar.gz"
   appcast 'https://github.com/liberationfonts/liberation-fonts/releases.atom'
-  name 'Liberation Sans'
+  name 'Liberation'
   homepage 'https://github.com/liberationfonts/liberation-fonts'
 
   font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-Bold.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---

In #2084, cask `font-liberation-sans` is renamed to `font-liberation`, but the `name` stanza of that cask is still `Liberation Sans`. This PR updates the `name` to `Liberation`.