### PR TITLE
Provide guidance for OpenType variable fonts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ This constraint may change in the future, when the backend Ruby code becomes mor
 
 ### Multiple Font Formats
 
-If a distribution provides the same font in multiple file formats, for example both OpenType and TrueType, only include one kind. We prefer OTF to TTF, and variable fonts to static files for different instantiations. Where a distribution provides variable and static fonts under different family names, both can be included for backwards compatibility as long as they can be contained within a single cask. For example, [Source Sans](https://github.com/adobe-fonts/source-sans-pro) provides separate 'Source Sans 3' and 'Source Sans 3 VF' families.
+If a distribution provides the same font in multiple file formats, for example both OpenType and TrueType, only include one kind. We prefer OTF to TTF, and variable fonts to static files for different instantiations. Where a distribution provides variable and static fonts under different family names, both can be included for backwards compatibility as long as they can be contained within a single cask. Example: [font-source-serif-pro.rb](https://github.com/Homebrew/homebrew-cask-fonts/blob/ab3e5d7d313b64c0a2c4041196a8eaa8e1539c9c/Casks/font-source-serif-pro.rb#L10#L23).
 
 Note that `font_casker` generates font stanzas for all files, so its output should be edited as needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,7 @@ This constraint may change in the future, when the backend Ruby code becomes mor
 
 ### Multiple Font Formats
 
-If a distribution provides multiple file formats for the same font, variable fonts are preferred over static files for different instantiations. TTF variable fonts (glyf-based) are more compatible than OTF (CFF2-based). For static instantiations, OTF is preferred to TTF.
-
-Where a distribution provides variable and static fonts under a different family name, both can be included for backwards compatibility. For example, [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) provides both 'Source Sans Pro' and 'Source Sans Variable' families.
+If a distribution provides the same font in multiple file formats, for example both OpenType and TrueType, only include one kind. We prefer OTF to TTF, and variable fonts to static files for different instantiations. Where a distribution provides variable and static fonts under different family names, both can be included for backwards compatibility as long as they can be contained within a single formula. For example, [Source Sans](https://github.com/adobe-fonts/source-sans-pro) provides separate 'Source Sans 3' and 'Source Sans 3 VF' families.
 
 Note that `font_casker` generates font stanzas for all files, so its output should be edited as needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,9 +113,9 @@ This constraint may change in the future, when the backend Ruby code becomes mor
 
 ### Multiple Font Formats
 
-If a distribution provides multiple file formats for the same font, for example both TTF and OTF files, only include one kind. OTF is preferred over TTF.
+If a distribution provides multiple file formats for the same font, variable fonts are preferred over static files for different instantiations. TTF variable fonts (glyf-based) are more compatible than OTF (CFF2-based). For static instantiations, OTF is preferred to TTF.
 
-OpenType variable fonts are preferred over static files for different instantiations. Where a distribution provides variable and static fonts under a different family name, both can be included for backwards compatibility. For example, [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) provides both 'Source Sans Pro' and 'Source Sans Variable' families.
+Where a distribution provides variable and static fonts under a different family name, both can be included for backwards compatibility. For example, [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) provides both 'Source Sans Pro' and 'Source Sans Variable' families.
 
 Note that `font_casker` generates font stanzas for all files, so its output should be edited as needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ This constraint may change in the future, when the backend Ruby code becomes mor
 
 ### Multiple Font Formats
 
-If a distribution provides the same font in multiple file formats, for example both OpenType and TrueType, only include one kind. We prefer OTF to TTF, and variable fonts to static files for different instantiations. Where a distribution provides variable and static fonts under different family names, both can be included for backwards compatibility as long as they can be contained within a single formula. For example, [Source Sans](https://github.com/adobe-fonts/source-sans-pro) provides separate 'Source Sans 3' and 'Source Sans 3 VF' families.
+If a distribution provides the same font in multiple file formats, for example both OpenType and TrueType, only include one kind. We prefer OTF to TTF, and variable fonts to static files for different instantiations. Where a distribution provides variable and static fonts under different family names, both can be included for backwards compatibility as long as they can be contained within a single cask. For example, [Source Sans](https://github.com/adobe-fonts/source-sans-pro) provides separate 'Source Sans 3' and 'Source Sans 3 VF' families.
 
 Note that `font_casker` generates font stanzas for all files, so its output should be edited as needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,8 @@ This constraint may change in the future, when the backend Ruby code becomes mor
 
 If a distribution provides multiple file formats for the same font, for example both TTF and OTF files, only include one kind. OTF is preferred over TTF.
 
+OpenType variable fonts are preferred over separate files for different weights. Where a distribution provides variable fonts under a different family name, both can be included for backwards compatibility. For example, [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) includes both the original 'Source Sans Pro' family and variable fonts that install under a separate 'Source Sans Variable' name.
+
 Note that `font_casker` generates font stanzas for all files, so its output should be edited as needed.
 
 ## Check Your Font Licenses

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ This constraint may change in the future, when the backend Ruby code becomes mor
 
 If a distribution provides multiple file formats for the same font, for example both TTF and OTF files, only include one kind. OTF is preferred over TTF.
 
-OpenType variable fonts are preferred over separate files for different weights. Where a distribution provides variable fonts under a different family name, both can be included for backwards compatibility. For example, [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) includes both the original 'Source Sans Pro' family and variable fonts that install under a separate 'Source Sans Variable' name.
+OpenType variable fonts are preferred over static files for different instantiations. Where a distribution provides variable and static fonts under a different family name, both can be included for backwards compatibility. For example, [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) provides both 'Source Sans Pro' and 'Source Sans Variable' families.
 
 Note that `font_casker` generates font stanzas for all files, so its output should be edited as needed.
 


### PR DESCRIPTION
When adding the font [Elstob](https://psb1558.github.io/Elstob-font/) (#2078), it emerged that there is no guidance for OpenType variable fonts. These provide more potential functionality, and are fully supported in the latest versions of macOS. A few older applications (notably LaTeX) cannot use them, and need separate files for each weight, but this is being rapidly remedied.

At the moment there are casks providing:

- only variable-width fonts ([Sudo](https://github.com/Homebrew/homebrew-cask-fonts/blob/57fc91532681f3fa7b3a269ede09ac821da8c931/Casks/font-sudo.rb) and [nearly fifty faces from Google Fonts](https://github.com/Homebrew/homebrew-cask-fonts/search?q=wght&unscoped_q=wght));
- only the separate files for different instantiations, even where OpenType variable fonts are available ([Source Code Pro](https://github.com/Homebrew/homebrew-cask-fonts/blob/2ee90f777bff57baac68f725fe4b1008476fc9cb/Casks/font-source-code-pro.rb), [Source Sans Pro](https://github.com/Homebrew/homebrew-cask-fonts/blob/2ee90f777bff57baac68f725fe4b1008476fc9cb/Casks/font-source-sans-pro.rb), [Source Serif Pro](https://github.com/Homebrew/homebrew-cask-fonts/blob/2ee90f777bff57baac68f725fe4b1008476fc9cb/Casks/font-source-serif-pro.rb), [Elstob](https://github.com/Homebrew/homebrew-cask-fonts/blob/f4b55455cdd8d1d2ea9f56edee74aff89c2b6a0d/Casks/font-elstobd.rb)) – corrected in #2077, #2105, #2106;
- both variable fonts and separate files for different weights ([League Spartan](https://github.com/Homebrew/homebrew-cask-fonts/blob/1837305bf78ba5e542595db9c31a382bb44fa394/Casks/font-league-spartan.rb)) – corrected in #2104.

The League Spartan example will result in the system viewing the font as being installed more than once (it will disable one of the copies).

Some developers, however, provide variable font families under a different name. If one installs both the standard OTFs and the variable fonts from the Source Sans Pro distribution, this will provide both 'Source Sans Pro' and 'Source Sans Variable' families, giving both backwards compatibility and access to the full feature set for applications that support it. I would propose that we allow both to be packaged in such circumstances.