### PR TITLE
League Spartan: Install variable font only

### DIFF
--- a/Casks/font-league-spartan.rb
+++ b/Casks/font-league-spartan.rb
@@ -8,13 +8,5 @@ cask 'font-league-spartan' do
   name 'League Spartan'
   homepage 'https://www.theleagueofmoveabletype.com/league-spartan'
 
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Black.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Bold.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Extrabold.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Extralight.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Light.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Medium.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Regular.otf"
-  font "league-spartan-#{version}/fonts/static/otf/LeagueSpartan-Semibold.otf"
   font "league-spartan-#{version}/fonts/variable/LeagueSpartanVariable.ttf"
 end


### PR DESCRIPTION
Installing both the static and variable fonts causes a conflict, since they use the same family name.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
