### PR TITLE
Update font-iosevka-curly-slab from 3.2.1 to 3.2.2

### DIFF
--- a/Casks/font-iosevka-curly-slab.rb
+++ b/Casks/font-iosevka-curly-slab.rb
@@ -1,6 +1,6 @@
 cask 'font-iosevka-curly-slab' do
-  version '3.2.1'
-  sha256 'db6c61ab67d75e054380531bb8fac962eb74f5e137bf1c9312e6223626670bf9'
+  version '3.2.2'
+  sha256 'f8a474d6c35996dd8cd4f2883c3a713daf8da5ec601e01efe7fd4c3ba82c59c8'
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-curly-slab-#{version}.zip"
   appcast 'https://github.com/be5invis/Iosevka/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).