### PR TITLE
Update font-iosevka-ss05 from 3.2.1 to 3.2.2

### DIFF
--- a/Casks/font-iosevka-ss05.rb
+++ b/Casks/font-iosevka-ss05.rb
@@ -1,6 +1,6 @@
 cask 'font-iosevka-ss05' do
-  version '3.2.1'
-  sha256 '2da9a0be1c4643631ed47fdc7d1643a75ff21a437587ab5afaa321d03d7e7e83'
+  version '3.2.2'
+  sha256 'fbf747e9f7eb8900df247567d2e0e54ea6abd022b2978b02acd662db4a361dab'
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss05-#{version}.zip"
   appcast 'https://github.com/be5invis/Iosevka/releases.atom'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).