### PR TITLE
Update font-libertinus from 6.11 to 6.12

### DIFF
--- a/Casks/font-libertinus.rb
+++ b/Casks/font-libertinus.rb
@@ -1,6 +1,6 @@
 cask 'font-libertinus' do
-  version '6.11'
-  sha256 '7baa736b16756b80bb13834bf70d430cc6abc41c48222b596363e2dcef96d0a1'
+  version '6.12'
+  sha256 '64249bc2ed80f41ffa78a5fdd396e53b4fb5601e469f0f93c842fc6a775ac9e7'
 
   url "https://github.com/alif-type/libertinus/archive/v#{version}.tar.gz"
   appcast 'https://github.com/alif-type/libertinus/releases.atom'


### PR DESCRIPTION
[Release notes for v6.12](https://github.com/alif-type/libertinus/releases/tag/v6.12).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
