### PR TITLE
Update font-cascadia from 2005.15 to 2007.01

### DIFF
--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,11 +1,16 @@
 cask 'font-cascadia-mono-pl' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono PL'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaMonoPL.otf'
+  font 'otf/CascadiaMonoPL-Bold.otf'
+  font 'otf/CascadiaMonoPL-ExtraLight.otf'
+  font 'otf/CascadiaMonoPL-Light.otf'
+  font 'otf/CascadiaMonoPL-Regular.otf'
+  font 'otf/CascadiaMonoPL-SemiBold.otf'
+  font 'otf/CascadiaMonoPL-SemiLight.otf'
 end

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,11 +1,16 @@
 cask 'font-cascadia-mono' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaMono.otf'
+  font 'otf/CascadiaMono-Bold.otf'
+  font 'otf/CascadiaMono-ExtraLight.otf'
+  font 'otf/CascadiaMono-Light.otf'
+  font 'otf/CascadiaMono-Regular.otf'
+  font 'otf/CascadiaMono-SemiBold.otf'
+  font 'otf/CascadiaMono-SemiLight.otf'
 end

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -1,11 +1,16 @@
 cask 'font-cascadia-pl' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia PL'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaCodePL.otf'
+  font 'otf/CascadiaCodePL-Bold.otf'
+  font 'otf/CascadiaCodePL-ExtraLight.otf'
+  font 'otf/CascadiaCodePL-Light.otf'
+  font 'otf/CascadiaCodePL-Regular.otf'
+  font 'otf/CascadiaCodePL-SemiBold.otf'
+  font 'otf/CascadiaCodePL-SemiLight.otf'
 end

--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,11 +1,16 @@
 cask 'font-cascadia' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaCode.otf'
+  font 'otf/CascadiaCode-Bold.otf'
+  font 'otf/CascadiaCode-ExtraLight.otf'
+  font 'otf/CascadiaCode-Light.otf'
+  font 'otf/CascadiaCode-Regular.otf'
+  font 'otf/CascadiaCode-SemiBold.otf'
+  font 'otf/CascadiaCode-SemiLight.otf'
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).