### PR TITLE
Update font-cascadia variants from 2005.15 to 2007.01

### DIFF
--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -2,7 +2,7 @@ cask 'font-cascadia-mono-pl' do
   version '2007.01'
   sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono PL'
   homepage 'https://github.com/microsoft/cascadia-code'

--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia-mono-pl' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono PL'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaMonoPL.otf'
+  font 'ttf/CascadiaMonoPL.ttf'
 end

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia-mono' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaMono.otf'
+  font 'ttf/CascadiaMono.ttf'
 end

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -2,7 +2,7 @@ cask 'font-cascadia-mono' do
   version '2007.01'
   sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia Mono'
   homepage 'https://github.com/microsoft/cascadia-code'

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia-pl' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia PL'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaCodePL.otf'
+  font 'ttf/CascadiaCodePL.ttf'
 end

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -2,7 +2,7 @@ cask 'font-cascadia-pl' do
   version '2007.01'
   sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia PL'
   homepage 'https://github.com/microsoft/cascadia-code'

--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,11 +1,11 @@
 cask 'font-cascadia' do
-  version '2005.15'
-  sha256 'b3d8495e9cdee90d0dbaf60b7db018413e130265dc27e2be7a8db04cf98fddce'
+  version '2007.01'
+  sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia'
   homepage 'https://github.com/microsoft/cascadia-code'
 
-  font 'otf/CascadiaCode.otf'
+  font 'ttf/CascadiaCode.ttf'
 end

--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -2,7 +2,7 @@ cask 'font-cascadia' do
   version '2007.01'
   sha256 '9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4'
 
-  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode_#{version}.zip"
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast 'https://github.com/microsoft/cascadia-code/releases.atom'
   name 'Cascadia'
   homepage 'https://github.com/microsoft/cascadia-code'


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

There are open pull requests:
- #2181 which fails
- #2182 which only updates `font-cascadia`, but lacks the derivates `font-cascadia-mono`, `font-cascadia-mono-pl` and `font-cascadia-pl`
