### PR TITLE
Update font-jetbrains-mono from 1.0.6 to 2.001

### DIFF
--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -1,27 +1,39 @@
 cask 'font-jetbrains-mono' do
-  version '1.0.6'
-  sha256 '2c2d660c46fa68f1b4ae087990b0742b12a7585e96b9e791adb28583251c0472'
+  version '2.001'
+  sha256 'd9176856e982ca16f4ee24a1021a62b51cea43575f3c6aa1910d4cdf6b695ade'
 
   # github.com/JetBrains/JetBrainsMono/ was verified as official when first introduced to the cask
-  url "https://github.com/JetBrains/JetBrainsMono/releases/download/v#{version}/JetBrainsMono-#{version}.zip"
+  url "https://github.com/JetBrains/JetBrainsMono/releases/download/v#{version}/JetBrains.Mono.#{version}.zip"
   appcast 'https://github.com/JetBrains/JetBrainsMono/releases.atom'
   name 'JetBrains Mono'
   homepage 'https://www.jetbrains.com/lp/mono'
 
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Bold-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Bold.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Bold.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-ExtraBold-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-ExtraBold.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-ExtraBold.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Medium-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium-Italic.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Medium.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Medium.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMono-Regular.ttf"
-  font "JetBrainsMono-#{version}/ttf/JetBrainsMonoNL-Regular.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Bold-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Bold.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-ExtraBold-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-ExtraBold.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-ExtraLight-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-ExtraLight.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Light-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Light.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Medium-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Medium.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-Regular.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-SemiLight-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/JetBrainsMono-SemiLight.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Bold-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Bold.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-ExtraBold-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-ExtraBold.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-ExtraLight-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-ExtraLight.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Light-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Light.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Medium-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Medium.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-Regular.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-SemiLight-Italic.ttf"
+  font "JetBrains Mono #{version}/ttf/No ligatures/JetBrainsMonoNL-SemiLight.ttf"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).