### PR TITLE
Update font-spleen from 1.8.1 to 1.8.2

### DIFF
--- a/Casks/font-spleen.rb
+++ b/Casks/font-spleen.rb
@@ -1,6 +1,6 @@
 cask "font-spleen" do
-  version "1.8.1"
-  sha256 "59119044399b2262fdf4c504c6f1a8b1230d349dfd07c68a2fb07a394a880e1e"
+  version "1.8.2"
+  sha256 "16262d8e403486252c9541b9b1b5c2847c4e7329d214ca2e7f9889f83b196fdf"
 
   url "https://github.com/fcambus/spleen/releases/download/#{version}/spleen-#{version}.tar.gz"
   appcast "https://github.com/fcambus/spleen/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).