### PR TITLE
Update font-hackgen-nerd from 2.1.0 to 2.1.1

### DIFF
--- a/Casks/font-hackgen-nerd.rb
+++ b/Casks/font-hackgen-nerd.rb
@@ -1,6 +1,6 @@
 cask "font-hackgen-nerd" do
-  version "2.1.0"
-  sha256 "678e1597448ccf75ba29a1f47600f5aded00ab13220ca3db99ad3b1266e5dfa4"
+  version "2.1.1"
+  sha256 "e776dc97e2b265f768f412040a5a64bc10066d6bc8082f2a5aa5a03a02578219"
 
   url "https://github.com/yuru7/HackGen/releases/download/v#{version}/HackGenNerd_v#{version}.zip"
   appcast "https://github.com/yuru7/HackGen/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).