### PR TITLE
Update font-work-sans to 2.010

### DIFF
--- a/Casks/font-work-sans.rb
+++ b/Casks/font-work-sans.rb
@@ -1,9 +1,10 @@
 cask "font-work-sans" do
-  version :latest
-  sha256 :no_check
+  version "2.010"
+  sha256 "44e05ffb17d97205ec85feb82edcb2f6f99ef0874074096cec0d64f1b5af1973"
 
   # github.com/weiweihuanghuang/Work-Sans/ was verified as official when first introduced to the cask
-  url "https://github.com/weiweihuanghuang/Work-Sans/archive/master.zip"
+  url "https://github.com/weiweihuanghuang/Work-Sans/archive/#{version}.zip"
+  appcast "https://github.com/weiweihuanghuang/Work-Sans/releases.atom"
   name "Work Sans"
   homepage "https://weiweihuanghuang.github.io/Work-Sans/"
 


### PR DESCRIPTION
The author has [started](https://github.com/weiweihuanghuang/Work-Sans/issues/48) to release tagged versions on GitHub again, so we can use the explicit version for new releases. (cf. [previous PR](https://github.com/Homebrew/homebrew-cask-fonts/pull/2030))

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

