### PR TITLE
automatically import Google Fonts

### DIFF
--- a/.github/workflows/google_fonts.yml
+++ b/.github/workflows/google_fonts.yml
@@ -3,7 +3,7 @@ name: Update Google Fonts
 on:
   push: # TODO remove
   schedule:
-    - cron: "0 0 * * *" # daily
+    - cron: "0 0 * * 0" # weekly
 
 jobs:
   update:
@@ -27,8 +27,13 @@ jobs:
       - name: Import Google Fonts
         run: ./developer/bin/import_google_fonts vendor/google-fonts
 
-      - name: Commit updated files
-        uses: EndBug/add-and-commit@v4
+      - name: Create pull request with updated files
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
         with:
-          add: Casks
-          message: automatic import of Google Fonts from GitHub Actions
+          branch: auto-update-google-fonts
+          commit-message: automatic import of Google Fonts
+          base: master
+          title: automatic import of Google Fonts
+      - name: Print output
+        run: echo "Created pull request https://github.com/${{ github.repository }}/${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/google_fonts.yml
+++ b/.github/workflows/google_fonts.yml
@@ -1,0 +1,34 @@
+name: Update Google Fonts
+
+on:
+  push: # TODO remove
+  schedule:
+    - cron: "0 0 * * *" # daily
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout homebrew-cask-fonts
+        uses: actions/checkout@v2
+      - name: Checkout google/fonts
+        uses: actions/checkout@v2
+        with:
+          repository: google/fonts
+          path: vendor/google-fonts
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Python packages
+        run: pip3 install gftools jinja2 protobuf
+
+      - name: Import Google Fonts
+        run: ./developer/bin/import_google_fonts vendor/google-fonts
+
+      - name: Commit updated files
+        uses: EndBug/add-and-commit@v4
+        with:
+          add: Casks
+          message: automatic import of Google Fonts from GitHub Actions


### PR DESCRIPTION
Rather than have to run the Google Font updates manually, this pull request adds a GitHub Actions workflow to do it automatically. You can see the example runs [here](https://github.com/afeld/homebrew-cask-fonts/actions?query=branch%3Aauto-import-google+workflow%3A%22Update+Google+Fonts%22).