### PR TITLE
Update font-cascadia variants from 2007.01 to 2008.25

### DIFF
--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,11 +1,16 @@
 cask "font-cascadia-mono-pl" do
-  version "2007.01"
-  sha256 "9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4"
+  version "2008.25"
+  sha256 "4602a0b8b986b18a1c3f460fd959ec1ce522aedcf11ab4c0d41a5fc5ed839be0"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"
   name "Cascadia Mono PL"
   homepage "https://github.com/microsoft/cascadia-code"
 
-  font "ttf/CascadiaMonoPL.ttf"
+  font "ttf/static/CascadiaMonoPL-Bold.ttf"
+  font "ttf/static/CascadiaMonoPL-ExtraLight.ttf"
+  font "ttf/static/CascadiaMonoPL-Light.ttf"
+  font "ttf/static/CascadiaMonoPL-Regular.ttf"
+  font "ttf/static/CascadiaMonoPL-SemiBold.ttf"
+  font "ttf/static/CascadiaMonoPL-SemiLight.ttf"
 end

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,11 +1,16 @@
 cask "font-cascadia-mono" do
-  version "2007.01"
-  sha256 "9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4"
+  version "2008.25"
+  sha256 "4602a0b8b986b18a1c3f460fd959ec1ce522aedcf11ab4c0d41a5fc5ed839be0"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"
   name "Cascadia Mono"
   homepage "https://github.com/microsoft/cascadia-code"
 
-  font "ttf/CascadiaMono.ttf"
+  font "ttf/static/CascadiaMono-Bold.ttf"
+  font "ttf/static/CascadiaMono-ExtraLight.ttf"
+  font "ttf/static/CascadiaMono-Light.ttf"
+  font "ttf/static/CascadiaMono-Regular.ttf"
+  font "ttf/static/CascadiaMono-SemiBold.ttf"
+  font "ttf/static/CascadiaMono-SemiLight.ttf"
 end

--- a/Casks/font-cascadia-pl.rb
+++ b/Casks/font-cascadia-pl.rb
@@ -1,11 +1,16 @@
 cask "font-cascadia-pl" do
-  version "2007.01"
-  sha256 "9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4"
+  version "2008.25"
+  sha256 "4602a0b8b986b18a1c3f460fd959ec1ce522aedcf11ab4c0d41a5fc5ed839be0"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"
   name "Cascadia PL"
   homepage "https://github.com/microsoft/cascadia-code"
 
-  font "ttf/CascadiaCodePL.ttf"
+  font "ttf/static/CascadiaCodePL-Bold.ttf"
+  font "ttf/static/CascadiaCodePL-ExtraLight.ttf"
+  font "ttf/static/CascadiaCodePL-Light.ttf"
+  font "ttf/static/CascadiaCodePL-Regular.ttf"
+  font "ttf/static/CascadiaCodePL-SemiBold.ttf"
+  font "ttf/static/CascadiaCodePL-SemiLight.ttf"
 end

--- a/Casks/font-cascadia.rb
+++ b/Casks/font-cascadia.rb
@@ -1,11 +1,16 @@
 cask "font-cascadia" do
-  version "2007.01"
-  sha256 "9f066d0d9cb2669bea2e130d7add43d496bf24ef995f42dc603fc2014574a3a4"
+  version "2008.25"
+  sha256 "4602a0b8b986b18a1c3f460fd959ec1ce522aedcf11ab4c0d41a5fc5ed839be0"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"
   name "Cascadia"
   homepage "https://github.com/microsoft/cascadia-code"
 
-  font "ttf/CascadiaCode.ttf"
+  font "ttf/static/CascadiaCode-Bold.ttf"
+  font "ttf/static/CascadiaCode-ExtraLight.ttf"
+  font "ttf/static/CascadiaCode-Light.ttf"
+  font "ttf/static/CascadiaCode-Regular.ttf"
+  font "ttf/static/CascadiaCode-SemiBold.ttf"
+  font "ttf/static/CascadiaCode-SemiLight.ttf"
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Switched from variable fonts (CascadiaMono.ttf) to static fonts (CascadiaMono-Bold.ttf, CascadiaMono-Regular.ttf, …) as the static versions are hinted using ttfautohint, hence look smoother than the variable fonts at small and intermediate point sizes.