### PR TITLE
Updated font-px437-pxplus and added conflicts_with statement for font…

### DIFF
--- a/Casks/font-px437-pxplus.rb
+++ b/Casks/font-px437-pxplus.rb
@@ -1,12 +1,14 @@
 cask "font-px437-pxplus" do
-  version "1.0"
-  sha256 "7666cf23176e34ea03a218b5c1500f4ad729d97150ab7bdb7cf2adf4c99a9a7a"
+  version "1.01"
+  sha256 "992f37be922610249ae4287dec8418bcfdbddc0b76502ec9df974270ced0f462"
 
-  url "https://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v#{version}.zip"
+  url "https://int10h.org/oldschool-pc-fonts/download/oldschool_pc_font_pack_v#{version}.zip"
   name "Px437"
   name "PxPlus"
   name "Ultimate Oldschool PC Font Pack"
   homepage "https://int10h.org/oldschool-pc-fonts/"
+
+  conflicts_with cask: "font-437-plus"
 
   font "Px437 (TrueType - DOS charset)/Px437_AMI_BIOS-2y.ttf"
   font "Px437 (TrueType - DOS charset)/Px437_AMI_BIOS.ttf"


### PR DESCRIPTION
…-437-plus

Note: The newly-added conflicts_with statement assumes that font-437-plus is accepted as a new formula in https://github.com/Homebrew/homebrew-cask-fonts/pull/2394

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
