### PR TITLE
Update font-iosevka-ss02 from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/font-iosevka-ss02.rb
+++ b/Casks/font-iosevka-ss02.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss02" do
-  version "3.6.0"
-  sha256 "751516624629330c9bbcc1679532e89434c9c38121c5a3f9e889e3e4f9566efb"
+  version "3.6.1"
+  sha256 "40533d615454a67346d74876a91c1fe3a42f6a73585a3abdd0c4b17fa111c27c"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss02-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).