### PR TITLE
Update font-iosevka-ss05 from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/font-iosevka-ss05.rb
+++ b/Casks/font-iosevka-ss05.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss05" do
-  version "3.6.0"
-  sha256 "e42d58c4a426e5babead99a14a333f9407c0e8b2e4b029136470767ba6091089"
+  version "3.6.1"
+  sha256 "249c71d598961f76faf46c1da3d64dae8d07c2d3f2054e170ef3e83bb4f7b135"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss05-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).