### PR TITLE
Update font-iosevka-ss08 from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/font-iosevka-ss08.rb
+++ b/Casks/font-iosevka-ss08.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss08" do
-  version "3.6.0"
-  sha256 "401ddb27a271d7d1c490d908c471c6262d07f6b58c35da9a32e9cfbea6976b92"
+  version "3.6.1"
+  sha256 "03f4f354f058fa382487dfd052924101f3aa3b82c265209f067e1159d5587097"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss08-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).