### PR TITLE
Update font-iosevka-curly-slab from 3.6.0 to 3.6.1

### DIFF
--- a/Casks/font-iosevka-curly-slab.rb
+++ b/Casks/font-iosevka-curly-slab.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-curly-slab" do
-  version "3.6.0"
-  sha256 "b1c3c8193d48813717a4852278a1aec9971f4dd0e0e8ef2b3a5f8845def5d06f"
+  version "3.6.1"
+  sha256 "8594a5ca0bed51c976d9eacf4e72478e3abd87cf8879fb96c776ad9a33f36780"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-curly-slab-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).