### PR TITLE
Revert "Update font-cascadia variants from 2009.14 to 2009.21 (#2427)"

### DIFF
--- a/Casks/font-cascadia-code-pl.rb
+++ b/Casks/font-cascadia-code-pl.rb
@@ -1,6 +1,6 @@
 cask "font-cascadia-code-pl" do
-  version "2009.21"
-  sha256 "caf14bc8bba076d6c2c593dc70239f646e7f2e02702e5dca80e35607f7aa839b"
+  version "2009.14"
+  sha256 "7a08523d2d68ef3c6efdd5336dd49aa2698dd348fa4734463a17719632bbc3c8"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"

--- a/Casks/font-cascadia-code.rb
+++ b/Casks/font-cascadia-code.rb
@@ -1,6 +1,6 @@
 cask "font-cascadia-code" do
-  version "2009.21"
-  sha256 "caf14bc8bba076d6c2c593dc70239f646e7f2e02702e5dca80e35607f7aa839b"
+  version "2009.14"
+  sha256 "7a08523d2d68ef3c6efdd5336dd49aa2698dd348fa4734463a17719632bbc3c8"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"

--- a/Casks/font-cascadia-mono-pl.rb
+++ b/Casks/font-cascadia-mono-pl.rb
@@ -1,6 +1,6 @@
 cask "font-cascadia-mono-pl" do
-  version "2009.21"
-  sha256 "caf14bc8bba076d6c2c593dc70239f646e7f2e02702e5dca80e35607f7aa839b"
+  version "2009.14"
+  sha256 "7a08523d2d68ef3c6efdd5336dd49aa2698dd348fa4734463a17719632bbc3c8"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"

--- a/Casks/font-cascadia-mono.rb
+++ b/Casks/font-cascadia-mono.rb
@@ -1,6 +1,6 @@
 cask "font-cascadia-mono" do
-  version "2009.21"
-  sha256 "caf14bc8bba076d6c2c593dc70239f646e7f2e02702e5dca80e35607f7aa839b"
+  version "2009.14"
+  sha256 "7a08523d2d68ef3c6efdd5336dd49aa2698dd348fa4734463a17719632bbc3c8"
 
   url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
   appcast "https://github.com/microsoft/cascadia-code/releases.atom"


### PR DESCRIPTION
This reverts commit 9c932d7d41f986bbc564be557de8192144738aed.

There are no assets for font-cascadia variants version 2009.21

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).