### PR TITLE
Update font-iosevka-ss06 from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/font-iosevka-ss06.rb
+++ b/Casks/font-iosevka-ss06.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss06" do
-  version "3.6.1"
-  sha256 "65bb87ebfd6b61bbbb5833eefc18a0a892b8e024e754db32f11765f095c783ae"
+  version "3.6.2"
+  sha256 "d77087a684665865a6bd1346e4d0a73c894e4e870808e2b9fc08f3b4f63039ca"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss06-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).