### PR TITLE
Update font-iosevka-ss10 from 3.6.1 to 3.6.2

### DIFF
--- a/Casks/font-iosevka-ss10.rb
+++ b/Casks/font-iosevka-ss10.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss10" do
-  version "3.6.1"
-  sha256 "f66e74d6db400ae1a85f314e7b78d9ef310a281b21d7802c26247872923dbec7"
+  version "3.6.2"
+  sha256 "f0708d71e677d1ccfee168cd1490432bd5dcacf89471c5be7a5fab9f82a13807"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss10-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).