### PR TITLE
Update font-iosevka-ss05 from 3.6.2 to 3.6.3

### DIFF
--- a/Casks/font-iosevka-ss05.rb
+++ b/Casks/font-iosevka-ss05.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss05" do
-  version "3.6.2"
-  sha256 "5929de4ed5a2ecd40ff44f40115d81b746ad4d4a668b18809dc9dafe6f6b4206"
+  version "3.6.3"
+  sha256 "cb4af86c04de725b1bd5b091e4b2a4f46763576a18d5961de0440fc74ea33c1c"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss05-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).