### PR TITLE
Update font-iosevka-ss08 from 3.6.2 to 3.6.3

### DIFF
--- a/Casks/font-iosevka-ss08.rb
+++ b/Casks/font-iosevka-ss08.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss08" do
-  version "3.6.2"
-  sha256 "223fde702c73c50eff9bbed1a5232023f5846e3454855ce24300fdfa2fb0ee6c"
+  version "3.6.3"
+  sha256 "ec72155c5e2c644b605d022349c12bee3d7394391e41fc322c141fccb85ee1ab"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss08-#{version}.zip"
   appcast "https://github.com/be5invis/Iosevka/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).