### PR TITLE
Update font-libertinus from 7.010 to 7.020

### DIFF
--- a/Casks/font-libertinus.rb
+++ b/Casks/font-libertinus.rb
@@ -1,6 +1,6 @@
 cask "font-libertinus" do
-  version "7.010"
-  sha256 "d7b9cd1a1e56d11721db2093a09e96972420e03a5662394f81a793ee6998c746"
+  version "7.020"
+  sha256 "87fced5821ffcad0c94a7086d5325e2c679c24e201c500406173b769df16b6d7"
 
   url "https://github.com/alerque/libertinus/releases/download/v#{version}/Libertinus-#{version}.tar.xz"
   appcast "https://github.com/alerque/libertinus/releases.atom"


### PR DESCRIPTION
Release notes: https://github.com/alerque/libertinus/releases/tag/v7.020

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
