### PR TITLE
Update font-juliamono from 0.022 to 0.023

### DIFF
--- a/Casks/font-juliamono.rb
+++ b/Casks/font-juliamono.rb
@@ -1,6 +1,6 @@
 cask "font-juliamono" do
-  version "0.022"
-  sha256 "cbed22ede8b72705e856f0cda4b2c63d3aea48efc2962076520fd529febf8acb"
+  version "0.023"
+  sha256 "9558bc1737f280849193f71c975c311768f3c43dd913c14d6021a9d86c6db809"
 
   url "https://github.com/cormullion/juliamono/releases/download/v#{version}/JuliaMono.tar.gz"
   appcast "https://github.com/cormullion/juliamono/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
