### PR TITLE
Update font-league-gothic from 1.560 to 1.601

### DIFF
--- a/Casks/font-league-gothic.rb
+++ b/Casks/font-league-gothic.rb
@@ -1,13 +1,16 @@
 cask "font-league-gothic" do
-  version :latest
-  sha256 :no_check
+  version "1.601"
+  sha256 "a1d9d3aaba2abda2791eaad03d51dbfd97aa6f6f2ea23c3b2b2b31f90d8cbeb5"
 
-  url "http://files.theleagueofmoveabletype.com/downloads/theleagueof-league-gothic-64c3ede.zip"
+  # github.com/theleagueof/league-gothic/ was verified as official when first introduced to the cask
+  url "https://github.com/theleagueof/league-gothic/releases/download/#{version}/LeagueGothic-#{version}.tar.xz"
+  appcast "https://github.com/theleagueof/league-gothic/releases.atom"
   name "League Gothic"
+  desc "Revival of an old classic, Alternate Gothic #1"
   homepage "https://www.theleagueofmoveabletype.com/league-gothic"
 
-  font "theleagueof-league-gothic-64c3ede/LeagueGothic-CondensedItalic.otf"
-  font "theleagueof-league-gothic-64c3ede/LeagueGothic-CondensedRegular.otf"
-  font "theleagueof-league-gothic-64c3ede/LeagueGothic-Italic.otf"
-  font "theleagueof-league-gothic-64c3ede/LeagueGothic-Regular.otf"
+  font "LeagueGothic-#{version}/static/OTF/LeagueGothic-Regular.otf"
+  font "LeagueGothic-#{version}/static/OTF/LeagueGothic-Italic.otf"
+  font "LeagueGothic-#{version}/static/OTF/LeagueGothic-Condensed.otf"
+  font "LeagueGothic-#{version}/static/OTF/LeagueGothic-CondensedItalic.otf"
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).