### PR TITLE
Update font-source-code-pro to 2.032R-ro-1.052R-it-1.012R-VAR

### DIFF
--- a/Casks/font-source-code-pro.rb
+++ b/Casks/font-source-code-pro.rb
@@ -1,9 +1,9 @@
 cask "font-source-code-pro" do
-  version "2.030R-ro-1.050R-it"
-  sha256 "da2ac159497d31b0c6d9daa8fc390fb8252e75b4a9805ace6a2c9cccaed4932e"
+  version "2.032R-ro-1.052R-it-1.012R-VAR"
+  sha256 "4d28868a2dc4cd6b767a91cd3d8462983aa8924ae18149f3b1d1a135090a0f8d"
 
   # github.com/adobe-fonts/source-code-pro/ was verified as official when first introduced to the cask
-  url "https://github.com/adobe-fonts/source-code-pro/archive/#{version.sub("ro-", "ro/")}.zip"
+  url "https://github.com/adobe-fonts/source-code-pro/archive/#{version.gsub(/(?<=ro)-|(?<=it)-/, "/")}.zip"
   appcast "https://github.com/adobe-fonts/source-code-pro/releases.atom"
   name "Source Code Pro"
   homepage "https://adobe-fonts.github.io/source-code-pro/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask-fonts/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).


Closes https://github.com/Homebrew/homebrew-cask-fonts/issues/2639.