### PR TITLE
font-tt2020: remove ASCII versions

### DIFF
--- a/Casks/font-tt2020.rb
+++ b/Casks/font-tt2020.rb
@@ -16,8 +16,6 @@ cask "font-tt2020" do
   font "TT2020-#{version}/dist/TT2020StyleD-Regular.ttf"
   font "TT2020-#{version}/dist/TT2020StyleE-Italic.ttf"
   font "TT2020-#{version}/dist/TT2020StyleE-Regular.ttf"
-  font "TT2020-#{version}/dist/TT2020StyleF-Regular-ASCII.ttf"
   font "TT2020-#{version}/dist/TT2020StyleF-Regular.ttf"
-  font "TT2020-#{version}/dist/TT2020StyleG-Regular-ASCII.ttf"
   font "TT2020-#{version}/dist/TT2020StyleG-Regular.ttf"
 end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask-fonts/commit/67aa25e89b8b24dcc75461e73602ccdd6d7c71a2#r44681192