### PR TITLE
Update font-source-han-sans from 2.001 to 2.002

### DIFF
--- a/Casks/font-source-han-sans.rb
+++ b/Casks/font-source-han-sans.rb
@@ -1,6 +1,6 @@
 cask "font-source-han-sans" do
-  version "2.001"
-  sha256 "5eb728fc73f86b0e5f4129b6028eaf3cccc5ac4782e93e7c90323f6a550218a0"
+  version "2.002"
+  sha256 "8f78220f16845de12e3bb0dc460c082ffcd3871e5f92cbb0934cdeccffb48dbb"
 
   url "https://github.com/adobe-fonts/source-han-sans/raw/#{version}R/SuperOTC/SourceHanSans.ttc.zip"
   name "Source Han Sans"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).