### PR TITLE
Update font-libertinus from 7.020 to 7.031

### DIFF
--- a/Casks/font-libertinus.rb
+++ b/Casks/font-libertinus.rb
@@ -1,6 +1,6 @@
 cask "font-libertinus" do
-  version "7.020"
-  sha256 "87fced5821ffcad0c94a7086d5325e2c679c24e201c500406173b769df16b6d7"
+  version "7.031"
+  sha256 "32cdd2cbd9927b9bda1d500c50faefffa0e1d989b4fbb3ea010dc3efd4495eb0"
 
   url "https://github.com/alerque/libertinus/releases/download/v#{version}/Libertinus-#{version}.tar.xz"
   appcast "https://github.com/alerque/libertinus/releases.atom"


### PR DESCRIPTION
- Overhaul dot placement on all Latin capitals with dot-above
- Align dot-below on ṃ U+1E43 below middle stroke of m
- Remove bogus glyphs encoded as subscripts from Display and Serif Semibold
- Drop inappropriate kerning classes from ₘ U+2098 and ₙ U+2099
- Zero out kerns between super/subscript glyphs
- Add glyph for U+0453 to Cyrillic Italic styles
- Enable support for Macedonian localized Italics
- Expand range of available angle bracket sizes in Math family
- Add alternative slanted integrals to Math family (as feature +ss08)