### PR TITLE
font jetbrains mono 2.225

### DIFF
--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -37,4 +37,6 @@ cask "font-jetbrains-mono" do
   font "fonts/ttf/JetBrainsMonoNL-Regular.ttf"
   font "fonts/ttf/JetBrainsMonoNL-Thin.ttf"
   font "fonts/ttf/JetBrainsMonoNL-ThinItalic.ttf"
+  font "fonts/variable/JetBrainsMono-Italic[wght].ttf"
+  font "fonts/variable/JetBrainsMono[wght].ttf"
 end

--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -1,6 +1,6 @@
 cask "font-jetbrains-mono" do
-  version "2.221"
-  sha256 "2fcbc70aca5ddabcfdbbc536c2b5f65ccf798ff13d8078738cbbef84c57e99a9"
+  version "2.225"
+  sha256 "03b2e2c0e3285703a204b6efbe2d277bf568e0bb53a395e9f4e74e9b77c4aeb2"
 
   url "https://github.com/JetBrains/JetBrainsMono/releases/download/v#{version}/JetBrainsMono-#{version}.zip",
       verified: "github.com/JetBrains/JetBrainsMono/"


### PR DESCRIPTION
- Update font-jetbrains-mono from 2.224 to 2.225
- font-jetbrains-mono 2.225: add variable fonts since all issues raised in #2187 are closed

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
