### PR TITLE
CONTRIBUTING.md: new rules for including casks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 [Instructions from the main repository](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md) apply. Exceptions are documented on the [README](README.md) and this document.
 
+## When to contribute
+
+The preferred way to add a font to this repository is to [submit it to Google Fonts](https://github.com/google/fonts/blob/master/CONTRIBUTING.md). Shortly after its inclusion, a Cask will be automatically generated and updated on this repository.
+
+We accept fonts from other sources **but they must be provably popular**, like [JetBrains Mono](https://github.com/JetBrains/JetBrainsMono) and [iA Fonts](https://github.com/iaolo/iA-Fonts). To build one of those, keep reading.
+
 ## Adding a Font Cask
 
 Making a Font Cask is easy: a Cask is a small Ruby file.


### PR DESCRIPTION
Homebrew/cask-fonts is a somewhat complex repo to maintain. Consistent naming is complicated, popularity metrics are unreliable, and casks stay broken for long stretches without anyone noticing. In short, the repo is a bit of a mess (and growing) which is complicated and unrewarding to clean up.

What if we shift the bulk of the work somewhere else, to an entity who cares about organising fonts? While [Google isn’t an example of keeping projects alive](https://killedbygoogle.com), [Google Fonts is open-source](https://github.com/google/fonts) and has no signs of slowing down.

A large portion of our fonts are from their repo and we have [a Workflow](https://github.com/Homebrew/homebrew-cask-fonts/actions/workflows/google-fonts.yml) which takes care of syncing them. That means that if fonts are added there instead of here, more people will benefit: people who use Google Fonts but not Homebrew will have access to them and we reduce our maintenance effort while keeping fonts in better shape. Everyone wins.