### PR TITLE
Remove duplicate fonts from font-jetbrains-mono

### DIFF
--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -4,10 +4,14 @@ cask "font-jetbrains-mono" do
 
   url "https://github.com/JetBrains/JetBrainsMono/releases/download/v#{version}/JetBrainsMono-#{version}.zip",
       verified: "github.com/JetBrains/JetBrainsMono/"
-  appcast "https://github.com/JetBrains/JetBrainsMono/releases.atom"
   name "JetBrains Mono"
   desc "Typeface made for developers"
   homepage "https://www.jetbrains.com/lp/mono"
+
+  livecheck do
+    url "https://github.com/JetBrains/JetBrainsMono/releases.atom"
+    strategy :sparkle
+  end
 
   font "fonts/ttf/JetBrainsMono-Bold.ttf"
   font "fonts/ttf/JetBrainsMono-BoldItalic.ttf"
@@ -37,6 +41,4 @@ cask "font-jetbrains-mono" do
   font "fonts/ttf/JetBrainsMonoNL-Regular.ttf"
   font "fonts/ttf/JetBrainsMonoNL-Thin.ttf"
   font "fonts/ttf/JetBrainsMonoNL-ThinItalic.ttf"
-  font "fonts/variable/JetBrainsMono-Italic[wght].ttf"
-  font "fonts/variable/JetBrainsMono[wght].ttf"
 end

--- a/Casks/font-jetbrains-mono.rb
+++ b/Casks/font-jetbrains-mono.rb
@@ -9,8 +9,8 @@ cask "font-jetbrains-mono" do
   homepage "https://www.jetbrains.com/lp/mono"
 
   livecheck do
-    url "https://github.com/JetBrains/JetBrainsMono/releases.atom"
-    strategy :sparkle
+    url "https://github.com/JetBrains/JetBrainsMono"
+    strategy :gitHub_latest
   end
 
   font "fonts/ttf/JetBrainsMono-Bold.ttf"
@@ -41,4 +41,6 @@ cask "font-jetbrains-mono" do
   font "fonts/ttf/JetBrainsMonoNL-Regular.ttf"
   font "fonts/ttf/JetBrainsMonoNL-Thin.ttf"
   font "fonts/ttf/JetBrainsMonoNL-ThinItalic.ttf"
+  font "fonts/variable/JetBrainsMono-Italic[wght].ttf"
+  font "fonts/variable/JetBrainsMono[wght].ttf"
 end


### PR DESCRIPTION
- Removed font `fonts/variable/JetBrainsMono[wght].ttf`, because it is marked as a duplicate of `fonts/ttf/JetBrainsMono.ttf` (in `Font Book.app`)
- Removed font `fonts/variable/JetBrainsMono-Italic[wght].ttf`, because it is marked as a duplicate of `fonts/ttf/JetBrainsMono-Light.ttf` (in `Font Book.app`)
- Also switched from `appcast` stanza to `livecheck`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
