### PR TITLE
Don't use SVN to clone a GitHub repo

### DIFF
--- a/Casks/font-source-code-pro.rb
+++ b/Casks/font-source-code-pro.rb
@@ -3,8 +3,7 @@ cask "font-source-code-pro" do
   sha256 :no_check
 
   url "https://github.com/google/fonts/trunk/ofl/sourcecodepro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+      verified: "github.com/google/fonts/"
   name "Source Code Pro"
   homepage "https://fonts.google.com/specimen/Source+Code+Pro"
 


### PR DESCRIPTION
Currently brew fails to update the font and says "You must: brew install svn". The pull request that made this change added this to other formulas, so it seems like the bot needs to be fixed.