### PR TITLE
space-grotesk: update to 2.0.0 and update font files

### DIFF
--- a/Casks/font-space-grotesk.rb
+++ b/Casks/font-space-grotesk.rb
@@ -1,15 +1,13 @@
 cask "font-space-grotesk" do
-  version "1.1.0"
-  sha256 "a4aaf23fe43de4096ce85c3b8dec7076c15ec5d0b8dbfbc65e91da5b173ea8e6"
+  version "2.0.0"
+  sha256 "53b415577d4139248555300710bea0d268c7a5be67b93de53b716a9736cabffd"
 
-  url "https://github.com/floriankarsten/space-grotesk/releases/download/#{version}/SpaceGrotesk-v#{version}.zip"
-  appcast "https://github.com/floriankarsten/space-grotesk/releases.atom"
+  url "https://github.com/floriankarsten/space-grotesk/releases/download/#{version}/SpaceGrotesk-#{version}.zip"
   name "Space Grotesk"
   homepage "https://github.com/floriankarsten/space-grotesk"
 
-  font "SpaceGrotesk-v#{version}/otf/SpaceGrotesk-Bold.otf"
-  font "SpaceGrotesk-v#{version}/otf/SpaceGrotesk-Light.otf"
-  font "SpaceGrotesk-v#{version}/otf/SpaceGrotesk-Medium.otf"
-  font "SpaceGrotesk-v#{version}/otf/SpaceGrotesk-Regular.otf"
-  font "SpaceGrotesk-v#{version}/otf/SpaceGrotesk-SemiBold.otf"
+  font "SpaceGrotesk-#{version}/otf/SpaceGrotesk-Bold.otf"
+  font "SpaceGrotesk-#{version}/otf/SpaceGrotesk-Light.otf"
+  font "SpaceGrotesk-#{version}/otf/SpaceGrotesk-Medium.otf"
+  font "SpaceGrotesk-#{version}/otf/SpaceGrotesk-Regular.otf"
 end


### PR DESCRIPTION


After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.