### PR TITLE
font_casker: update style

### DIFF
--- a/developer/bin/font_casker
+++ b/developer/bin/font_casker
@@ -116,9 +116,9 @@ end
 
 def stanzify(stanza_name, val = "")
   if val.respond_to?(:map)
-    val.map { |x| "  #{stanza_name} '#{x}'" }
+    val.map { |x| "  #{stanza_name} \"#{x}\"" }
   else
-    "  #{stanza_name} '#{val}'"
+    "  #{stanza_name} \"#{val}\""
   end
 end
 


### PR DESCRIPTION
Updates the font_casker util to return output with " instead of ' to meet specified rubocop standards