### PR TITLE
font-d2coding: update livecheck

### DIFF
--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -3,9 +3,16 @@ cask "font-d2coding" do
   sha256 "0f1c9192eac7d56329dddc620f9f1666b707e9c8ed38fe1f988d0ae3e30b24e6"
 
   url "https://github.com/naver/d2codingfont/releases/download/VER#{version.before_comma}/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.zip"
-  appcast "https://github.com/naver/d2codingfont/releases.atom"
   name "D2 Coding"
   homepage "https://github.com/naver/d2codingfont"
+
+  livecheck do
+    url "https://github.com/naver/d2codingfont/releases/latest"
+    strategy :page_match do |page|
+      page.scan(/href=.*?D2Coding[._-](?:Ver)?(\d+(?:\.\d+)+)[_-](\d+)\.zip/i)
+          .map { |matches| "#{matches[0]},#{matches[1]}" }
+    end
+  end
 
   font "D2Coding/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.ttc"
 end


### PR DESCRIPTION
The standard git livecheck picks up the wrong version as latest (1.31)

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.