### PR TITLE
font-liberation: update from 2.1.1 to 2.1.4, add livecheck

### DIFF
--- a/Casks/font-liberation.rb
+++ b/Casks/font-liberation.rb
@@ -1,11 +1,18 @@
 cask "font-liberation" do
-  version "2.1.1,4743886"
-  sha256 "8ee2c16fe0f055e60dd8375449aff72d25dd623b9cc6f24790ce9d2e91446fca"
+  version "2.1.4,6418984"
+  sha256 "26f85412dd0aa9d061504a1cc8aaf0aa12a70710e8d47d8b65a1251757c1a5ef"
 
   url "https://github.com/liberationfonts/liberation-fonts/files/#{version.after_comma}/liberation-fonts-ttf-#{version.before_comma}.tar.gz"
-  appcast "https://github.com/liberationfonts/liberation-fonts/releases.atom"
   name "Liberation"
   homepage "https://github.com/liberationfonts/liberation-fonts"
+
+  livecheck do
+    url "https://github.com/liberationfonts/liberation-fonts/releases/latest"
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?files/(\d+)/liberation[._-]fonts[._-]ttf[._-]v?(\d+(?:\.\d+)+)\.t}i)
+          .map { |matches| "#{matches[1]},#{matches[0]}" }
+    end
+  end
 
   font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-Bold.ttf"
   font "liberation-fonts-ttf-#{version.before_comma}/LiberationMono-BoldItalic.ttf"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.