### PR TITLE
iosevka: update livecheck strategy to github_latest

### DIFF
--- a/Casks/font-iosevka-aile.rb
+++ b/Casks/font-iosevka-aile.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-aile" do
   name "Iosevka Aile"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-aile-bold.ttc"
   font "iosevka-aile-extrabold.ttc"

--- a/Casks/font-iosevka-aile.rb
+++ b/Casks/font-iosevka-aile.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-aile" do
   name "Iosevka Aile"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-curly-slab.rb
+++ b/Casks/font-iosevka-curly-slab.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-curly-slab" do
   name "Iosevka Curly Slab"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-curly-slab.rb
+++ b/Casks/font-iosevka-curly-slab.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-curly-slab" do
   name "Iosevka Curly Slab"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-curly-slab-bold.ttc"
   font "iosevka-curly-slab-extrabold.ttc"

--- a/Casks/font-iosevka-curly.rb
+++ b/Casks/font-iosevka-curly.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-curly" do
   name "Iosevka Curly"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-curly-bold.ttc"
   font "iosevka-curly-extrabold.ttc"

--- a/Casks/font-iosevka-curly.rb
+++ b/Casks/font-iosevka-curly.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-curly" do
   name "Iosevka Curly"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-etoile.rb
+++ b/Casks/font-iosevka-etoile.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-etoile" do
   name "Iosevka Etoile"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-etoile-bold.ttc"
   font "iosevka-etoile-extrabold.ttc"

--- a/Casks/font-iosevka-etoile.rb
+++ b/Casks/font-iosevka-etoile.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-etoile" do
   name "Iosevka Etoile"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-slab.rb
+++ b/Casks/font-iosevka-slab.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-slab" do
   name "Iosevka Slab"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-slab.rb
+++ b/Casks/font-iosevka-slab.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-slab" do
   name "Iosevka Slab"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-slab-bold.ttc"
   font "iosevka-slab-extrabold.ttc"

--- a/Casks/font-iosevka-ss01.rb
+++ b/Casks/font-iosevka-ss01.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss01" do
   name "Iosevka SS01"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss01.rb
+++ b/Casks/font-iosevka-ss01.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss01" do
   name "Iosevka SS01"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss01-bold.ttc"
   font "iosevka-ss01-extrabold.ttc"

--- a/Casks/font-iosevka-ss02.rb
+++ b/Casks/font-iosevka-ss02.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss02" do
   name "Iosevka SS02"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss02.rb
+++ b/Casks/font-iosevka-ss02.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss02" do
   name "Iosevka SS02"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss02-bold.ttc"
   font "iosevka-ss02-extrabold.ttc"

--- a/Casks/font-iosevka-ss03.rb
+++ b/Casks/font-iosevka-ss03.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss03" do
   name "Iosevka SS03"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss03-bold.ttc"
   font "iosevka-ss03-extrabold.ttc"

--- a/Casks/font-iosevka-ss03.rb
+++ b/Casks/font-iosevka-ss03.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss03" do
   name "Iosevka SS03"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss04.rb
+++ b/Casks/font-iosevka-ss04.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss04" do
   name "Iosevka SS04"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss04-bold.ttc"
   font "iosevka-ss04-extrabold.ttc"

--- a/Casks/font-iosevka-ss04.rb
+++ b/Casks/font-iosevka-ss04.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss04" do
   name "Iosevka SS04"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss05.rb
+++ b/Casks/font-iosevka-ss05.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss05" do
   name "Iosevka SS05"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss05-bold.ttc"
   font "iosevka-ss05-extrabold.ttc"

--- a/Casks/font-iosevka-ss05.rb
+++ b/Casks/font-iosevka-ss05.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss05" do
   name "Iosevka SS05"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss06.rb
+++ b/Casks/font-iosevka-ss06.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss06" do
   name "Iosevka SS06"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss06-bold.ttc"
   font "iosevka-ss06-extrabold.ttc"

--- a/Casks/font-iosevka-ss06.rb
+++ b/Casks/font-iosevka-ss06.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss06" do
   name "Iosevka SS06"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss07.rb
+++ b/Casks/font-iosevka-ss07.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss07" do
   name "Iosevka SS07"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss07.rb
+++ b/Casks/font-iosevka-ss07.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss07" do
   name "Iosevka SS07"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss07-bold.ttc"
   font "iosevka-ss07-extrabold.ttc"

--- a/Casks/font-iosevka-ss08.rb
+++ b/Casks/font-iosevka-ss08.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss08" do
   name "Iosevka SS08"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss08.rb
+++ b/Casks/font-iosevka-ss08.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss08" do
   name "Iosevka SS08"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss08-bold.ttc"
   font "iosevka-ss08-extrabold.ttc"

--- a/Casks/font-iosevka-ss09.rb
+++ b/Casks/font-iosevka-ss09.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss09" do
   name "Iosevka SS09"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss09-bold.ttc"
   font "iosevka-ss09-extrabold.ttc"

--- a/Casks/font-iosevka-ss09.rb
+++ b/Casks/font-iosevka-ss09.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss09" do
   name "Iosevka SS09"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss10.rb
+++ b/Casks/font-iosevka-ss10.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss10" do
   name "Iosevka SS10"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss10.rb
+++ b/Casks/font-iosevka-ss10.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss10" do
   name "Iosevka SS10"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss10-bold.ttc"
   font "iosevka-ss10-extrabold.ttc"

--- a/Casks/font-iosevka-ss11.rb
+++ b/Casks/font-iosevka-ss11.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss11" do
   name "Iosevka SS11"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss11-bold.ttc"
   font "iosevka-ss11-extrabold.ttc"

--- a/Casks/font-iosevka-ss11.rb
+++ b/Casks/font-iosevka-ss11.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss11" do
   name "Iosevka SS11"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss12.rb
+++ b/Casks/font-iosevka-ss12.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss12" do
   name "Iosevka SS12"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss12-bold.ttc"
   font "iosevka-ss12-extrabold.ttc"

--- a/Casks/font-iosevka-ss12.rb
+++ b/Casks/font-iosevka-ss12.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss12" do
   name "Iosevka SS12"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss13.rb
+++ b/Casks/font-iosevka-ss13.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss13" do
   name "Iosevka SS13"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss13-bold.ttc"
   font "iosevka-ss13-extrabold.ttc"

--- a/Casks/font-iosevka-ss13.rb
+++ b/Casks/font-iosevka-ss13.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss13" do
   name "Iosevka SS13"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss14.rb
+++ b/Casks/font-iosevka-ss14.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss14" do
   name "Iosevka SS14"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss14.rb
+++ b/Casks/font-iosevka-ss14.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss14" do
   name "Iosevka SS14"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss14-bold.ttc"
   font "iosevka-ss14-extrabold.ttc"

--- a/Casks/font-iosevka-ss15.rb
+++ b/Casks/font-iosevka-ss15.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss15" do
   name "Iosevka SS15"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss15.rb
+++ b/Casks/font-iosevka-ss15.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss15" do
   name "Iosevka SS15"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss15-bold.ttc"
   font "iosevka-ss15-extrabold.ttc"

--- a/Casks/font-iosevka-ss16.rb
+++ b/Casks/font-iosevka-ss16.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss16" do
   name "Iosevka SS16"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss16-bold.ttc"
   font "iosevka-ss16-extrabold.ttc"

--- a/Casks/font-iosevka-ss16.rb
+++ b/Casks/font-iosevka-ss16.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss16" do
   name "Iosevka SS16"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss17.rb
+++ b/Casks/font-iosevka-ss17.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss17" do
   name "Iosevka SS17"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss17.rb
+++ b/Casks/font-iosevka-ss17.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss17" do
   name "Iosevka SS17"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss17-bold.ttc"
   font "iosevka-ss17-extrabold.ttc"

--- a/Casks/font-iosevka-ss18.rb
+++ b/Casks/font-iosevka-ss18.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-ss18" do
   name "Iosevka SS18"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/font-iosevka-ss18.rb
+++ b/Casks/font-iosevka-ss18.rb
@@ -6,6 +6,11 @@ cask "font-iosevka-ss18" do
   name "Iosevka SS18"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-ss18-bold.ttc"
   font "iosevka-ss18-extrabold.ttc"

--- a/Casks/font-iosevka.rb
+++ b/Casks/font-iosevka.rb
@@ -6,6 +6,11 @@ cask "font-iosevka" do
   name "Iosevka"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
+  
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   font "iosevka-bold.ttc"
   font "iosevka-extrabold.ttc"

--- a/Casks/font-iosevka.rb
+++ b/Casks/font-iosevka.rb
@@ -6,7 +6,7 @@ cask "font-iosevka" do
   name "Iosevka"
   desc "Sans-serif, slab-serif, monospace and quasi‑proportional typeface family"
   homepage "https://github.com/be5invis/Iosevka/"
-  
+
   livecheck do
     url :url
     strategy :github_latest


### PR DESCRIPTION
This prevents livecheck from returning releases from the iosevka repo before the fonts have finished building.
Will need to be rebased after the latest version updates are completed before running audits.

----

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.