### PR TITLE
Cask fonts audit exception

### DIFF
--- a/Casks/font-gilbert.rb
+++ b/Casks/font-gilbert.rb
@@ -1,6 +1,6 @@
 cask "font-gilbert" do
-  version "1.004,alpha"
-  sha256 "0cea7456bdc704c9b68c023a6bb40590e327da3d84f8ff5511c6460a712987a9"
+  version "1.005,alpha"
+  sha256 "d3ac3075efe00bf4302264b2e626f548e3549740d359a43991605b2a180d8cbe"
 
   url "https://github.com/Fontself/TypeWithPride/releases/download/#{version.before_comma}/Gilbert_#{version.before_comma}_#{version.after_comma}.zip",
       verified: "github.com/Fontself/TypeWithPride/"

--- a/Casks/font-gilbert.rb
+++ b/Casks/font-gilbert.rb
@@ -4,10 +4,17 @@ cask "font-gilbert" do
 
   url "https://github.com/Fontself/TypeWithPride/releases/download/#{version.before_comma}/Gilbert_#{version.before_comma}_#{version.after_comma}.zip",
       verified: "github.com/Fontself/TypeWithPride/"
-  appcast "https://github.com/Fontself/TypeWithPride/releases.atom"
   name "Gilbert"
   homepage "https://typewithpride.com/"
 
-  font "Gilbert_#{version.before_comma}_#{version.after_comma}/Gilbert Bold-Preview_#{version.before_comma.no_dots}.otf"
-  font "Gilbert_#{version.before_comma}_#{version.after_comma}/Gilbert-Color Bold-Preview_#{version.before_comma.no_dots}.otf"
+  livecheck do
+    url "https://github.com/Fontself/TypeWithPride/releases/"
+    strategy :page_match do |page|
+      page.scan(/href=.*?Gilbert[._-]v?(\d+(?:\.\d+)+)[._-](.*)\.zip/i)
+          .map { |matches| "#{matches[0]},#{matches[1]}" }
+    end
+  end
+
+  font "Gilbert_#{version.before_comma}_#{version.after_comma}/Gilbert Bold-Preview_#{version.before_comma.minor.tr("00", "")}.otf"
+  font "Gilbert_#{version.before_comma}_#{version.after_comma}/Gilbert-Color Bold-Preview_#{version.before_comma.minor.tr("00", "")}.otf"
 end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,0 +1,3 @@
+{
+    "font-gilbert": "all"
+}


### PR DESCRIPTION
This would allow  #4644 and any other added fonts to pass CI where their releases are specified as pre-releases on Github.