### PR TITLE
Create github prereleases allowlist

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,0 +1,3 @@
+{
+    "font-gilbert": "all"
+}


### PR DESCRIPTION
This would allow  #4644 and any other added fonts to pass CI where their releases are specified as pre-releases on Github.