### PR TITLE
font-material-icons: add livecheck

### DIFF
--- a/Casks/font-material-icons.rb
+++ b/Casks/font-material-icons.rb
@@ -4,9 +4,13 @@ cask "font-material-icons" do
 
   url "https://github.com/google/material-design-icons/archive/#{version}.zip",
       verified: "github.com/google/material-design-icons/"
-  appcast "https://github.com/google/material-design-icons/releases.atom"
   name "Material Icons"
   homepage "https://google.github.io/material-design-icons/"
+
+  livecheck do
+    url "https://google.github.io/material-design-icons/"
+    regex(/href=.*?material[._-]design[._-]icons[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   font "material-design-icons-#{version}/iconfont/MaterialIcons-Regular.ttf"
 end


### PR DESCRIPTION
The material icons Github repo releases do not line up with their latest `stable` release, found on their [homepage](https://google.github.io/material-design-icons/#getting-icons).

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.