### PR TITLE
font-museo: update url

### DIFF
--- a/Casks/font-museo.rb
+++ b/Casks/font-museo.rb
@@ -2,7 +2,8 @@ cask "font-museo" do
   version "2.002"
   sha256 :no_check
 
-  url "http://www.abstractfonts.com/download/14890?option=zip"
+  url "https://abstractfonts-downloads.s3.amazonaws.com/zips/1/4/8/9/0/contents/museo-300.zip",
+      verified: "abstractfonts-downloads.s3.amazonaws.com/"
   name "Museo"
   homepage "http://www.abstractfonts.com/font/14890"
 


### PR DESCRIPTION
Fixes #5115 

The URL may not be 100% reliable, so if it fails we may need to remove this cask in future, as it seems that FontSpring is the preferred distributor - http://www.josbuivenga.demon.nl/