### PR TITLE
Temporarily patch import_google_fonts

### DIFF
--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -262,7 +262,10 @@ Download the or clone the repository from https://github.com/google/fonts, then 
         # check if the metadata file is present
         # https://github.com/google/fonts/issues/2512
         if os.path.exists(meta_file):
-            cask = metadata_to_cask(meta_file, repo_dir)
+            try:
+                cask = metadata_to_cask(meta_file, repo_dir)
+            except text_format.ParseError:
+                continue
         else:
             cask = derive_cask(family_folder, repo_dir)
 


### PR DESCRIPTION
With v0.8.3, gftools no longer includes the `source_type` field in its protobuf definitions. However, v0.8.2 is also no longer usable due to additions made in the same commit that removed `source_type`. This patch sacrifices the few remaining fonts that define a `source_type` in order to allow the script to continue running correctly.

I've opened googlefonts/gftools#454 to find out what the future of `source_type` is, and will follow this patch up with a more permanent solution once I get a response there.

I've also opened follow-ups to this PR (#5273, #5274 and #5275 for additions, updates and deletions respectively) with the results of a manual run to clear the backlog created over [the past ~5 months of failing CI runs](https://github.com/Homebrew/homebrew-cask-fonts/actions/workflows/google-fonts.yml).