### PR TITLE
Update font-roboto.rb

### DIFF
--- a/Casks/font-roboto.rb
+++ b/Casks/font-roboto.rb
@@ -2,7 +2,7 @@ cask "font-roboto" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/roboto",
+  url "https://github.com/google/fonts/tree/main/apache/roboto",
       verified: "github.com/google/fonts/",
       using:    :svn
   name "Roboto"

--- a/Casks/font-roboto.rb
+++ b/Casks/font-roboto.rb
@@ -2,9 +2,11 @@ cask "font-roboto" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/raw/main/apache/roboto",
-      verified: "github.com/google/fonts/"
+  url "https://github.com/google/fonts/trunk/apache/roboto",
+      verified: "github.com/google/fonts/",
+      using:    :svn
   name "Roboto"
+  desc "Font with a mechanical skeleton and the forms are largely geometric"
   homepage "https://fonts.google.com/specimen/Roboto"
 
   font "Roboto-Italic[wdth,wght].ttf"

--- a/Casks/font-roboto.rb
+++ b/Casks/font-roboto.rb
@@ -2,9 +2,8 @@ cask "font-roboto" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/tree/main/apache/roboto",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts/raw/main/apache/roboto",
+      verified: "github.com/google/fonts/"
   name "Roboto"
   homepage "https://fonts.google.com/specimen/Roboto"
 


### PR DESCRIPTION
URL has changed.

I guess other google fonts are affected by this change, too.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
