### PR TITLE
Add font "LXGW Bright"

### DIFF
--- a/Casks/font-lxgw-bright.rb
+++ b/Casks/font-lxgw-bright.rb
@@ -1,0 +1,16 @@
+cask "font-lxgw-bright" do
+  version "1.120"
+  sha256 "076b147e4df1785ae26068821c661c8528a34efa53119fe1438d8a0824f9cb3a"
+
+  url "https://github.com/lxgw/LxgwBright/archive/refs/tags/v#{version}.zip"
+  name "LXGW Bright"
+  desc "Merged font of Ysabeau Office and LXGW WenKai"
+  homepage "https://github.com/lxgw/LxgwBright"
+
+  font "LxgwBright-#{version}/OTF/LXGWBright-Medium.otf"
+  font "LxgwBright-#{version}/OTF/LXGWBright-MediumItalic.otf"
+  font "LxgwBright-#{version}/OTF/LXGWBright-Regular.otf"
+  font "LxgwBright-#{version}/OTF/LXGWBright-Italic.otf"
+  font "LxgwBright-#{version}/OTF/LXGWBright-SemiLight.otf"
+  font "LxgwBright-#{version}/OTF/LXGWBright-SemiLightItalic.otf"
+end

--- a/Casks/font-lxgw-bright.rb
+++ b/Casks/font-lxgw-bright.rb
@@ -1,6 +1,6 @@
 cask "font-lxgw-bright" do
-  version "1.120"
-  sha256 "076b147e4df1785ae26068821c661c8528a34efa53119fe1438d8a0824f9cb3a"
+  version "1.210"
+  sha256 "ea33dbbb4c5d9dea290ba74e29248046a6ca2ced32b2eb022a3f23a839a325ee"
 
   url "https://github.com/lxgw/LxgwBright/archive/refs/tags/v#{version}.zip"
   name "LXGW Bright"


### PR DESCRIPTION
This font is just a merged version of "LXGW WenKai" and "Ysabeau Office", so I hope it could be released at the same time as "LXGW WenKai".

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
