### PR TITLE
Update font-material-icons to latest

### DIFF
--- a/Casks/font-material-icons.rb
+++ b/Casks/font-material-icons.rb
@@ -1,16 +1,16 @@
 cask "font-material-icons" do
-  version "3.0.1"
-  sha256 "722e3b09121b82a3746f3da2ecd3a2db8d7d24153b8433324315695a45f06a90"
+  version :latest
+  sha256 :no_check
 
-  url "https://github.com/google/material-design-icons/archive/#{version}.zip",
-      verified: "github.com/google/material-design-icons/"
+  url "https://github.com/google/material-design-icons/trunk/font",
+      verified: "github.com/google/material-design-icons/",
+      using:    :svn
   name "Material Icons"
   homepage "https://google.github.io/material-design-icons/"
 
-  livecheck do
-    url "https://google.github.io/material-design-icons/"
-    regex(/href=.*?material[._-]design[._-]icons[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-  end
-
-  font "material-design-icons-#{version}/iconfont/MaterialIcons-Regular.ttf"
+  font "MaterialIcons-Regular.ttf"
+  font "MaterialIconsOutlined-Regular.otf"
+  font "MaterialIconsRound-Regular.otf"
+  font "MaterialIconsSharp-Regular.otf"
+  font "MaterialIconsTwoTone-Regular.otf"
 end

--- a/Casks/font-material-icons.rb
+++ b/Casks/font-material-icons.rb
@@ -1,12 +1,11 @@
 cask "font-material-icons" do
-  version :latest
-  sha256 :no_check
+  version "4.0.0"
+  sha256 "3decc1c1f9b2352dafc769df58d1044293818a758bac150cc817fa377933f9a9"
 
-  url "https://github.com/google/material-design-icons/trunk/font",
-      verified: "github.com/google/material-design-icons/",
-      using:    :svn
+  url "https://github.com/google/material-design-icons/archive/refs/tags/#{version}.zip",
+      verified: "github.com/google/material-design-icons/"
   name "Material Icons"
-  homepage "https://google.github.io/material-design-icons/"
+  homepage "https://developers.google.com/fonts/docs/material_icons"
 
   font "MaterialIcons-Regular.ttf"
   font "MaterialIconsOutlined-Regular.otf"


### PR DESCRIPTION
Reasons for changing the cask url:
- Includes the latest icons.  The latest release of [google/material-design-icons](https://github.com/google/material-design-icons/) is not up to date with the actual icons listed at https://google.github.io/material-design-icons/.
- Downloads only the necessary files.  Installing from the release file takes FOREVER, since it requires downloading, decompressing, and moving around a lot of unnecessary files in addition to the font itself.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
