### PR TITLE
Update font-lxgw-wenkai from 1.222 to 1.230

### DIFF
--- a/Casks/font-lxgw-wenkai.rb
+++ b/Casks/font-lxgw-wenkai.rb
@@ -1,6 +1,6 @@
 cask "font-lxgw-wenkai" do
-  version "1.222"
-  sha256 "b593bef64fe20baafa0111a462288c2fd4c7d2d696583990a306b2d6493f60a8"
+  version "1.230"
+  sha256 "77390c8a9ac1281425ccf995fff20cb4da208e83463716e740e7c2d0379f1279"
 
   url "https://github.com/lxgw/LxgwWenKai/releases/download/v#{version}/lxgw-wenkai-v#{version}.zip"
   name "LXGW WenKai"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

https://github.com/lxgw/LxgwWenKai/releases/tag/v1.230

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
