### PR TITLE
Update font-lxgw-zhenkai from 0.5.5.1 to 0.552

### DIFF
--- a/Casks/font-lxgw-zhenkai.rb
+++ b/Casks/font-lxgw-zhenkai.rb
@@ -1,6 +1,6 @@
 cask "font-lxgw-zhenkai" do
-  version "0.5.5.1"
-  sha256 "72b78abb4d9b046d49eca6773bd98e1d9bf509781acb2a55f0b26eb5610af5a7"
+  version "0.552"
+  sha256 "42ad7194752057d752d7e41dc13c19c7b2d4e2818f1933f7399584419f377e15"
 
   url "https://github.com/lxgw/LxgwZhenKai/releases/download/v#{version}/LXGWZhenKai.ttf"
   name "LXGW ZhenKai"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

https://github.com/lxgw/LxgwZhenKai/releases/tag/v0.552

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
