### PR TITLE
Update repo's URL for font-source-code-pro.

### DIFF
--- a/Casks/font-source-code-pro.rb
+++ b/Casks/font-source-code-pro.rb
@@ -1,13 +1,39 @@
 cask "font-source-code-pro" do
-  version :latest
-  sha256 :no_check
+  version "2.038R-ro/1.058R-it/1.018R-VAR"
+  sha256 "87c94be199cd412e145081cf20dce1217196b47e407989465e687ebf0316af9e"
 
-  url "https://github.com/google/fonts/trunk/ofl/sourcecodepro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/adobe-fonts/source-code-pro/archive/refs/tags/#{version}.zip",
+      verified: "github.com/adobe-fonts/source-code-pro/"
   name "Source Code Pro"
-  homepage "https://fonts.google.com/specimen/Source+Code+Pro"
+  desc "Monospaced font family for user interface and coding environments"
+  homepage "https://adobe-fonts.github.io/source-code-pro/"
 
-  font "SourceCodePro-Italic[wght].ttf"
-  font "SourceCodePro[wght].ttf"
+  font "OTF/SourceCodePro-Black.otf"
+  font "OTF/SourceCodePro-BlackIt.otf"
+  font "OTF/SourceCodePro-Bold.otf"
+  font "OTF/SourceCodePro-BoldIt.otf"
+  font "OTF/SourceCodePro-ExtraLight.otf"
+  font "OTF/SourceCodePro-ExtraLightIt.otf"
+  font "OTF/SourceCodePro-It.otf"
+  font "OTF/SourceCodePro-Light.otf"
+  font "OTF/SourceCodePro-LightIt.otf"
+  font "OTF/SourceCodePro-Medium.otf"
+  font "OTF/SourceCodePro-MediumIt.otf"
+  font "OTF/SourceCodePro-Regular.otf"
+  font "OTF/SourceCodePro-Semibold.otf"
+  font "OTF/SourceCodePro-SemiboldIt.otf"
+  font "TTF/SourceCodePro-Black.ttf"
+  font "TTF/SourceCodePro-BlackIt.ttf"
+  font "TTF/SourceCodePro-Bold.ttf"
+  font "TTF/SourceCodePro-BoldIt.ttf"
+  font "TTF/SourceCodePro-ExtraLight.ttf"
+  font "TTF/SourceCodePro-ExtraLightIt.ttf"
+  font "TTF/SourceCodePro-It.ttf"
+  font "TTF/SourceCodePro-Light.ttf"
+  font "TTF/SourceCodePro-LightIt.ttf"
+  font "TTF/SourceCodePro-Medium.ttf"
+  font "TTF/SourceCodePro-MediumIt.ttf"
+  font "TTF/SourceCodePro-Regular.ttf"
+  font "TTF/SourceCodePro-Semibold.ttf"
+  font "TTF/SourceCodePro-SemiboldIt.ttf"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

I'm sorry to push this half working cask but the issue I have is the following:

```bash
$ brew install --cask Casks/font-source-code-pro.rb
Error: Cask 'font-source-code-pro' definition is invalid: 'version' stanza failed with: 2.038R-ro/1.058R-it/1.018R-VAR contains invalid characters: /!
```

if I'm trying to set the version as `latest` I got this issue:
```bash
$ brew install --cask Casks/font-source-code-pro.rb
==> Downloading https://github.com/adobe-fonts/source-code-pro/archive/refs/tags/2.038R-ro/1.058R-it/1.018R-VAR.zip
==> Downloading from https://codeload.github.com/adobe-fonts/source-code-pro/zip/refs/tags/2.038R-ro/1.058R-it/1.018R-VAR
==> Installing Cask font-source-code-pro
==> Purging files for version latest of Cask font-source-code-pro
Error: It seems the Font source '/usr/local/Caskroom/font-source-code-pro/latest/TTF/SourceCodePro-SemiboldIt.ttf' is not there.
```

I'm not sure what is the best option here, thanks for your help.