### PR TITLE
Add UDEV Gothic NF

### DIFF
--- a/Casks/font-udev-gothic-nf.rb
+++ b/Casks/font-udev-gothic-nf.rb
@@ -1,0 +1,26 @@
+cask "font-udev-gothic-nf" do
+  version "1.0.0"
+  sha256 "c431f9ce6762c21cdc2b2f32481b1374babb2cf50dc5e949f27a8f7101ecceeb"
+
+  url "https://github.com/yuru7/udev-gothic/releases/download/v#{version}/UDEVGothic_NF_v#{version}.zip"
+  name "UDEV Gothic NF"
+  desc "Integrate fonts from BIZ UD Gothic and JetBrains Mono"
+  homepage "https://github.com/yuru7/udev-gothic"
+
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NF-Bold.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NF-BoldItalic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NF-Italic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NF-Regular.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NFLG-Bold.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NFLG-BoldItalic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NFLG-Italic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothic35NFLG-Regular.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNF-Bold.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNF-BoldItalic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNF-Italic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNF-Regular.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNFLG-Bold.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNFLG-BoldItalic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNFLG-Italic.ttf"
+  font "UDEVGothic_NF_v#{version}/UDEVGothicNFLG-Regular.ttf"
+end


### PR DESCRIPTION
The UDEV Gothic font added in #5681 has a separate Nerd Font distribution binary in its repo, like the same author's [font-hackgen](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-hackgen.rb) and [font-hackgen-nerd](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-hackgen-nerd.rb).  I'd like to add `font-udev-gothic-nf` as well as `font-udev-gothic`.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
  - It fails with a ` GitHub repository too new (<30 days old)` error
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
