### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
           rm "${GITHUB_WORKSPACE}"
           mkdir "${GITHUB_WORKSPACE}"
   conclusion:
+    permissions:
+      contents: none
     name: conclusion
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/google-fonts.yml
+++ b/.github/workflows/google-fonts.yml
@@ -8,6 +8,9 @@ on:
     - cron: "0 0 * * 0" # weekly
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   google-fonts:
     name: ${{ matrix.mode }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
