### PR TITLE
Use git instead of svn for IBM Plex Mono

### DIFF
--- a/Casks/font-ibm-plex-mono.rb
+++ b/Casks/font-ibm-plex-mono.rb
@@ -2,11 +2,10 @@ cask "font-ibm-plex-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts",
+  url "https://github.com/google/fonts.git",
       verified:   "github.com/google/fonts",
       branch:     "main",
-      only_paths: ["ofl/ibmplexmono"],
-      using:      :git
+      only_paths: ["ofl/ibmplexmono"]
   name "IBM Plex Mono"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Mono"
 

--- a/Casks/font-ibm-plex-mono.rb
+++ b/Casks/font-ibm-plex-mono.rb
@@ -3,24 +3,24 @@ cask "font-ibm-plex-mono" do
   sha256 :no_check
 
   url "https://github.com/google/fonts.git",
-      verified:   "github.com/google/fonts",
-      branch:     "main",
-      only_paths: ["ofl/ibmplexmono"]
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexmono"
   name "IBM Plex Mono"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Mono"
 
-  font "ofl/ibmplexmono/IBMPlexMono-Bold.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-BoldItalic.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-ExtraLight.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-ExtraLightItalic.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-Italic.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-Light.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-LightItalic.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-Medium.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-MediumItalic.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-Regular.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-SemiBold.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-SemiBoldItalic.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-Thin.ttf"
-  font "ofl/ibmplexmono/IBMPlexMono-ThinItalic.ttf"
+  font "IBMPlexMono-Bold.ttf"
+  font "IBMPlexMono-BoldItalic.ttf"
+  font "IBMPlexMono-ExtraLight.ttf"
+  font "IBMPlexMono-ExtraLightItalic.ttf"
+  font "IBMPlexMono-Italic.ttf"
+  font "IBMPlexMono-Light.ttf"
+  font "IBMPlexMono-LightItalic.ttf"
+  font "IBMPlexMono-Medium.ttf"
+  font "IBMPlexMono-MediumItalic.ttf"
+  font "IBMPlexMono-Regular.ttf"
+  font "IBMPlexMono-SemiBold.ttf"
+  font "IBMPlexMono-SemiBoldItalic.ttf"
+  font "IBMPlexMono-Thin.ttf"
+  font "IBMPlexMono-ThinItalic.ttf"
 end

--- a/Casks/font-ibm-plex-mono.rb
+++ b/Casks/font-ibm-plex-mono.rb
@@ -7,6 +7,7 @@ cask "font-ibm-plex-mono" do
       branch:    "main",
       only_path: "ofl/ibmplexmono"
   name "IBM Plex Mono"
+  desc "Corporate typeface for IBM"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Mono"
 
   font "IBMPlexMono-Bold.ttf"

--- a/Casks/font-ibm-plex-mono.rb
+++ b/Casks/font-ibm-plex-mono.rb
@@ -2,24 +2,26 @@ cask "font-ibm-plex-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts",
+      verified:   "github.com/google/fonts",
+      branch:     "main",
+      only_paths: ["ofl/ibmplexmono"],
+      using:      :git
   name "IBM Plex Mono"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Mono"
 
-  font "IBMPlexMono-Bold.ttf"
-  font "IBMPlexMono-BoldItalic.ttf"
-  font "IBMPlexMono-ExtraLight.ttf"
-  font "IBMPlexMono-ExtraLightItalic.ttf"
-  font "IBMPlexMono-Italic.ttf"
-  font "IBMPlexMono-Light.ttf"
-  font "IBMPlexMono-LightItalic.ttf"
-  font "IBMPlexMono-Medium.ttf"
-  font "IBMPlexMono-MediumItalic.ttf"
-  font "IBMPlexMono-Regular.ttf"
-  font "IBMPlexMono-SemiBold.ttf"
-  font "IBMPlexMono-SemiBoldItalic.ttf"
-  font "IBMPlexMono-Thin.ttf"
-  font "IBMPlexMono-ThinItalic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-Bold.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-BoldItalic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-ExtraLight.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-ExtraLightItalic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-Italic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-Light.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-LightItalic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-Medium.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-MediumItalic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-Regular.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-SemiBold.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-SemiBoldItalic.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-Thin.ttf"
+  font "ofl/ibmplexmono/IBMPlexMono-ThinItalic.ttf"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Hello!

This is a draft PR to demonstrate how we could use the proposed support for git partial clones with sparse checkouts as an alternative to subversion, as [suggested](https://github.com/Homebrew/brew/pull/13232#issuecomment-1115868261) by @MikeMcQuaid.

Using this branch with the master branch of homebrew (which includes https://github.com/Homebrew/brew/pull/14035) shows that we retain the speed benefits of not fetching the full fonts repo:

```
~ $ time brew install --cask font-ibm-plex-mono
==> Cloning https://github.com/google/fonts.git
Cloning into '/Users/hmarr/Library/Caches/Homebrew/Cask/font-ibm-plex-mono--git-sparse'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
Warning: No checksum defined for cask 'font-ibm-plex-mono', skipping verification.
==> Installing Cask font-ibm-plex-mono
==> Moving Font 'IBMPlexMono-ThinItalic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-ThinItalic
==> Moving Font 'IBMPlexMono-BoldItalic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-BoldItalic
==> Moving Font 'IBMPlexMono-ExtraLight.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-ExtraLight
==> Moving Font 'IBMPlexMono-ExtraLightItalic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Extr
==> Moving Font 'IBMPlexMono-Italic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Italic.ttf'
==> Moving Font 'IBMPlexMono-Light.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Light.ttf'
==> Moving Font 'IBMPlexMono-LightItalic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-LightItal
==> Moving Font 'IBMPlexMono-Medium.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Medium.ttf'
==> Moving Font 'IBMPlexMono-MediumItalic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-MediumIt
==> Moving Font 'IBMPlexMono-Regular.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Regular.ttf'
==> Moving Font 'IBMPlexMono-SemiBold.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-SemiBold.ttf
==> Moving Font 'IBMPlexMono-SemiBoldItalic.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-SemiBo
==> Moving Font 'IBMPlexMono-Thin.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Thin.ttf'
==> Moving Font 'IBMPlexMono-Bold.ttf' to '/Users/hmarr/Library/Fonts/IBMPlexMono-Bold.ttf'
🍺  font-ibm-plex-mono was successfully installed!
brew install --cask font-ibm-plex-mono  5.31s user 2.14s system 79% cpu 9.369 total
```