### PR TITLE
Update font-public-sans.rb

### DIFF
--- a/Casks/font-public-sans.rb
+++ b/Casks/font-public-sans.rb
@@ -1,6 +1,6 @@
 cask "font-public-sans" do
   version "2.001"
-  sha256 "dd839c4436d4ffc4563517f64c47b8eae2da54e867aad3173da1bd7fef104597"
+  sha256 "88cacdf7cd03b31af8f1f83e1f51e0eb5a6052565a6c014c90c385f1ff2d13a5"
 
   url "https://github.com/uswds/public-sans/releases/download/v#{version}/public-sans-v#{version}.zip",
       verified: "github.com/uswds/public-sans/"


### PR DESCRIPTION
SHA256 checksum seems to be incorrect- getting a mismatch when running brew upgrade, or when manually checking it on file when downloading it directly from the repo. (https://github.com/uswds/public-sans/releases/tag/v2.001)
Have made this pull request with the checksum I get, please could someone confirm.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
