### PR TITLE
Update font-jsmath-cmbx10 download and homepage URLs

### DIFF
--- a/Casks/font-jsmath-cmbx10.rb
+++ b/Casks/font-jsmath-cmbx10.rb
@@ -1,6 +1,3 @@
-# typed: false
-# frozen_string_literal: true
-
 cask "font-jsmath-cmbx10" do
   version :latest
   sha256 :no_check


### PR DESCRIPTION
The canonical URL for `font-jsmath-cmbx10` has changed to use HTTPS, and the capitalization in part of the path has changed from `jsmath` to `jsMath`. Without that latter change, a redirect leads to the Union College math department homepage, not to the zip file containing the fonts (breaking the cask by downloading HTML in place of the zip). The PR solves that issue. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
  - no error; one warning for absent description originates upstream. 
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: N/A