### PR TITLE
[fix] Font-edu-qld-beginner URL to the correct one

### DIFF
--- a/Casks/font-edu-qld-beginner.rb
+++ b/Casks/font-edu-qld-beginner.rb
@@ -1,11 +1,11 @@
-cask "font-edu-qld-beginners" do
+cask "font-edu-qld-beginner" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/raw/main/ofl/eduqldbeginners/EduQLDBeginners%5Bwght%5D.ttf",
+  url "https://github.com/google/fonts/raw/main/ofl/eduqldbeginner/EduQLDBeginner%5Bwght%5D.ttf",
       verified: "github.com/google/fonts/"
   name "Edu QLD Beginners"
   homepage "https://fonts.google.com/specimen/Edu+QLD+Beginners"
 
-  font "EduQLDBeginners[wght].ttf"
+  font "EduQLDBeginner[wght].ttf"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [v] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [v] `brew audit --cask --online <cask>` is error-free.
- [v] `brew style --fix <cask>` reports no offenses.

## Rationale for the PR

Downloading `font-edu-qld-beginners` prompted in an error from `cURL` side citing 404 error. With further investigation, I discovered the following:

1. The font's [upstream repository](https://github.com/MezMerrit/AU-School-Handwriting-Fonts/tree/main/QLD-School-Fonts/fonts/ttf) showed that the font names were in the name of `EduQLDBeginner???.ttf`.

2. Google font's repository [that points to this font](https://github.com/google/fonts/commit/9950d8820308d749d3d222f0fa4324ade219b40b) also contains the correct information in the metadata.


However, I spotted an inconsistency with homebrew-cask-fonts' recipe where `EduQLDBeginners` was being used in place of `EduQLDBeginner` --- which may been the reason for the 404 error.

This PR fixes this issue and correctly installs the desired `EduQLDBeginner` fonts.