### PR TITLE
add font-martian-mono live check

### DIFF
--- a/Casks/font-martian-mono.rb
+++ b/Casks/font-martian-mono.rb
@@ -7,6 +7,11 @@ cask "font-martian-mono" do
   desc "Monospaced font from Evil Martians"
   homepage "https://github.com/evilmartians/mono"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   font "MartianMono-CnBd.otf"
   font "MartianMono-CnLt.otf"
   font "MartianMono-CnMd.otf"


### PR DESCRIPTION
I was not able to run brew checks locally, RubyGems failed to install a lot of gems. This is a pretty straightforward addition, I just copied the live check from cascadia-code, it shouldn't brake any checks (:

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
