### PR TITLE
Switch Google fonts from svn to git

### DIFF
--- a/Casks/font-abeezee.rb
+++ b/Casks/font-abeezee.rb
@@ -2,9 +2,10 @@ cask "font-abeezee" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/abeezee",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/abeezee"
   name "ABeeZee"
   homepage "https://fonts.google.com/specimen/ABeeZee"
 

--- a/Casks/font-abhaya-libre.rb
+++ b/Casks/font-abhaya-libre.rb
@@ -2,9 +2,10 @@ cask "font-abhaya-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/abhayalibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/abhayalibre"
   name "Abhaya Libre"
   homepage "https://fonts.google.com/specimen/Abhaya+Libre"
 

--- a/Casks/font-advent-pro.rb
+++ b/Casks/font-advent-pro.rb
@@ -2,9 +2,10 @@ cask "font-advent-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/adventpro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/adventpro"
   name "Advent Pro"
   homepage "https://fonts.google.com/specimen/Advent+Pro"
 

--- a/Casks/font-albert-sans.rb
+++ b/Casks/font-albert-sans.rb
@@ -2,9 +2,10 @@ cask "font-albert-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/albertsans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/albertsans"
   name "Albert Sans"
   desc "Modern geometric sans serif family"
   homepage "https://fonts.google.com/specimen/Albert+Sans"

--- a/Casks/font-alegreya-sans-sc.rb
+++ b/Casks/font-alegreya-sans-sc.rb
@@ -2,9 +2,10 @@ cask "font-alegreya-sans-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/alegreyasanssc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/alegreyasanssc"
   name "Alegreya Sans SC"
   homepage "https://fonts.google.com/specimen/Alegreya+Sans+SC"
 

--- a/Casks/font-alegreya-sc.rb
+++ b/Casks/font-alegreya-sc.rb
@@ -2,9 +2,10 @@ cask "font-alegreya-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/alegreyasc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/alegreyasc"
   name "Alegreya SC"
   homepage "https://fonts.google.com/specimen/Alegreya+SC"
 

--- a/Casks/font-aleo.rb
+++ b/Casks/font-aleo.rb
@@ -2,9 +2,10 @@ cask "font-aleo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/aleo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/aleo"
   name "Aleo"
   homepage "https://fonts.google.com/specimen/Aleo"
 

--- a/Casks/font-allan.rb
+++ b/Casks/font-allan.rb
@@ -2,9 +2,10 @@ cask "font-allan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/allan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/allan"
   name "Allan"
   homepage "https://fonts.google.com/specimen/Allan"
 

--- a/Casks/font-almarai.rb
+++ b/Casks/font-almarai.rb
@@ -2,9 +2,10 @@ cask "font-almarai" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/almarai",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/almarai"
   name "Almarai"
   homepage "https://fonts.google.com/specimen/Almarai"
 

--- a/Casks/font-almendra.rb
+++ b/Casks/font-almendra.rb
@@ -2,9 +2,10 @@ cask "font-almendra" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/almendra",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/almendra"
   name "Almendra"
   homepage "https://fonts.google.com/specimen/Almendra"
 

--- a/Casks/font-alumni-sans-collegiate-one.rb
+++ b/Casks/font-alumni-sans-collegiate-one.rb
@@ -2,9 +2,10 @@ cask "font-alumni-sans-collegiate-one" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/alumnisanscollegiateone",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/alumnisanscollegiateone"
   name "Alumni Sans Collegiate One"
   desc "Font inspired by Impact Black"
   homepage "https://fonts.google.com/specimen/Alumni+Sans+Collegiate+One"

--- a/Casks/font-alumni-sans-inline-one.rb
+++ b/Casks/font-alumni-sans-inline-one.rb
@@ -2,9 +2,10 @@ cask "font-alumni-sans-inline-one" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/alumnisansinlineone",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/alumnisansinlineone"
   name "Alumni Sans Inline One"
   homepage "https://fonts.google.com/specimen/Alumni+Sans+Inline+One"
 

--- a/Casks/font-alumni-sans-pinstripe.rb
+++ b/Casks/font-alumni-sans-pinstripe.rb
@@ -2,9 +2,10 @@ cask "font-alumni-sans-pinstripe" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/alumnisanspinstripe",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/alumnisanspinstripe"
   name "Alumni Sans Pinstripe"
   homepage "https://fonts.google.com/specimen/Alumni+Sans+Pinstripe"
 

--- a/Casks/font-alumni-sans.rb
+++ b/Casks/font-alumni-sans.rb
@@ -2,9 +2,10 @@ cask "font-alumni-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/alumnisans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/alumnisans"
   name "Alumni Sans"
   homepage "https://fonts.google.com/specimen/Alumni+Sans"
 

--- a/Casks/font-amaranth.rb
+++ b/Casks/font-amaranth.rb
@@ -2,9 +2,10 @@ cask "font-amaranth" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/amaranth",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/amaranth"
   name "Amaranth"
   homepage "https://fonts.google.com/specimen/Amaranth"
 

--- a/Casks/font-amatic-sc.rb
+++ b/Casks/font-amatic-sc.rb
@@ -2,9 +2,10 @@ cask "font-amatic-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/amaticsc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/amaticsc"
   name "Amatic SC"
   homepage "https://fonts.google.com/specimen/Amatic+SC"
 

--- a/Casks/font-amiko.rb
+++ b/Casks/font-amiko.rb
@@ -2,9 +2,10 @@ cask "font-amiko" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/amiko",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/amiko"
   name "Amiko"
   homepage "https://fonts.google.com/specimen/Amiko"
 

--- a/Casks/font-amita.rb
+++ b/Casks/font-amita.rb
@@ -2,9 +2,10 @@ cask "font-amita" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/amita",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/amita"
   name "Amita"
   homepage "https://fonts.google.com/specimen/Amita"
 

--- a/Casks/font-andada-pro.rb
+++ b/Casks/font-andada-pro.rb
@@ -2,9 +2,10 @@ cask "font-andada-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/andadapro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/andadapro"
   name "Andada Pro"
   desc "Organic-slab serif, hybrid style and medium contrast type for text"
   homepage "https://fonts.google.com/specimen/Andada+Pro"

--- a/Casks/font-anybody.rb
+++ b/Casks/font-anybody.rb
@@ -2,9 +2,10 @@ cask "font-anybody" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/anybody",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/anybody"
   name "Anybody"
   desc "10 degrees, noticable but subtle"
   homepage "https://fonts.google.com/specimen/Anybody"

--- a/Casks/font-arapey.rb
+++ b/Casks/font-arapey.rb
@@ -2,9 +2,10 @@ cask "font-arapey" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arapey",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arapey"
   name "Arapey"
   homepage "https://fonts.google.com/specimen/Arapey"
 

--- a/Casks/font-archivo-narrow.rb
+++ b/Casks/font-archivo-narrow.rb
@@ -2,9 +2,10 @@ cask "font-archivo-narrow" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/archivonarrow",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/archivonarrow"
   name "Archivo Narrow"
   homepage "https://fonts.google.com/specimen/Archivo+Narrow"
 

--- a/Casks/font-archivo.rb
+++ b/Casks/font-archivo.rb
@@ -2,9 +2,10 @@ cask "font-archivo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/archivo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/archivo"
   name "Archivo"
   homepage "https://fonts.google.com/specimen/Archivo"
 

--- a/Casks/font-aref-ruqaa-ink.rb
+++ b/Casks/font-aref-ruqaa-ink.rb
@@ -2,9 +2,10 @@ cask "font-aref-ruqaa-ink" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arefruqaaink",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arefruqaaink"
   name "Aref Ruqaa Ink"
   desc "Led by khaled hosny, a type designer based in cairo, egypt"
   homepage "https://fonts.google.com/specimen/Aref+Ruqaa+Ink"

--- a/Casks/font-aref-ruqaa.rb
+++ b/Casks/font-aref-ruqaa.rb
@@ -2,9 +2,10 @@ cask "font-aref-ruqaa" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arefruqaa",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arefruqaa"
   name "Aref Ruqaa"
   homepage "https://fonts.google.com/specimen/Aref+Ruqaa"
 

--- a/Casks/font-arima-madurai.rb
+++ b/Casks/font-arima-madurai.rb
@@ -2,9 +2,10 @@ cask "font-arima-madurai" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arimamadurai",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arimamadurai"
   name "Arima Madurai"
   homepage "https://fonts.google.com/specimen/Arima+Madurai"
 

--- a/Casks/font-arimo.rb
+++ b/Casks/font-arimo.rb
@@ -2,9 +2,10 @@ cask "font-arimo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/arimo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/arimo"
   name "Arimo"
   homepage "https://fonts.google.com/specimen/Arimo"
 

--- a/Casks/font-arsenal.rb
+++ b/Casks/font-arsenal.rb
@@ -2,9 +2,10 @@ cask "font-arsenal" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arsenal",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arsenal"
   name "Arsenal"
   homepage "https://fonts.google.com/specimen/Arsenal"
 

--- a/Casks/font-arvo.rb
+++ b/Casks/font-arvo.rb
@@ -2,9 +2,10 @@ cask "font-arvo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arvo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arvo"
   name "Arvo"
   homepage "https://fonts.google.com/specimen/Arvo"
 

--- a/Casks/font-arya.rb
+++ b/Casks/font-arya.rb
@@ -2,9 +2,10 @@ cask "font-arya" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/arya",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/arya"
   name "Arya"
   homepage "https://fonts.google.com/specimen/Arya"
 

--- a/Casks/font-asap-condensed.rb
+++ b/Casks/font-asap-condensed.rb
@@ -2,9 +2,10 @@ cask "font-asap-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/asapcondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/asapcondensed"
   name "Asap Condensed"
   homepage "https://fonts.google.com/specimen/Asap+Condensed"
 

--- a/Casks/font-asap-vf-beta.rb
+++ b/Casks/font-asap-vf-beta.rb
@@ -2,9 +2,10 @@ cask "font-asap-vf-beta" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/asapvfbeta",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/asapvfbeta"
   name "Asap VF Beta"
   homepage "https://fonts.google.com/earlyaccess"
 

--- a/Casks/font-asap.rb
+++ b/Casks/font-asap.rb
@@ -2,9 +2,10 @@ cask "font-asap" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/asap",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/asap"
   name "Asap"
   homepage "https://fonts.google.com/specimen/Asap"
 

--- a/Casks/font-astloch.rb
+++ b/Casks/font-astloch.rb
@@ -2,9 +2,10 @@ cask "font-astloch" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/astloch",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/astloch"
   name "Astloch"
   homepage "https://fonts.google.com/specimen/Astloch"
 

--- a/Casks/font-asul.rb
+++ b/Casks/font-asul.rb
@@ -2,9 +2,10 @@ cask "font-asul" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/asul",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/asul"
   name "Asul"
   homepage "https://fonts.google.com/specimen/Asul"
 

--- a/Casks/font-athiti.rb
+++ b/Casks/font-athiti.rb
@@ -2,9 +2,10 @@ cask "font-athiti" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/athiti",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/athiti"
   name "Athiti"
   homepage "https://fonts.google.com/specimen/Athiti"
 

--- a/Casks/font-atma.rb
+++ b/Casks/font-atma.rb
@@ -2,9 +2,10 @@ cask "font-atma" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/atma",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/atma"
   name "Atma"
   homepage "https://fonts.google.com/specimen/Atma"
 

--- a/Casks/font-averia-libre.rb
+++ b/Casks/font-averia-libre.rb
@@ -2,9 +2,10 @@ cask "font-averia-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/averialibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/averialibre"
   name "Averia Libre"
   homepage "https://fonts.google.com/specimen/Averia+Libre"
 

--- a/Casks/font-averia-sans-libre.rb
+++ b/Casks/font-averia-sans-libre.rb
@@ -2,9 +2,10 @@ cask "font-averia-sans-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/averiasanslibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/averiasanslibre"
   name "Averia Sans Libre"
   homepage "https://fonts.google.com/specimen/Averia+Sans+Libre"
 

--- a/Casks/font-averia-serif-libre.rb
+++ b/Casks/font-averia-serif-libre.rb
@@ -2,9 +2,10 @@ cask "font-averia-serif-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/averiaseriflibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/averiaseriflibre"
   name "Averia Serif Libre"
   homepage "https://fonts.google.com/specimen/Averia+Serif+Libre"
 

--- a/Casks/font-azeret-mono.rb
+++ b/Casks/font-azeret-mono.rb
@@ -2,9 +2,10 @@ cask "font-azeret-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/azeretmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/azeretmono"
   name "Azeret Mono"
   desc "Designed by martin vácha and daniel quisek"
   homepage "https://fonts.google.com/specimen/Azeret+Mono"

--- a/Casks/font-b612-mono.rb
+++ b/Casks/font-b612-mono.rb
@@ -2,9 +2,10 @@ cask "font-b612-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/b612mono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/b612mono"
   name "B612 Mono"
   homepage "https://fonts.google.com/specimen/B612+Mono"
 

--- a/Casks/font-bai-jamjuree.rb
+++ b/Casks/font-bai-jamjuree.rb
@@ -2,9 +2,10 @@ cask "font-bai-jamjuree" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/baijamjuree",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/baijamjuree"
   name "Bai Jamjuree"
   homepage "https://fonts.google.com/specimen/Bai+Jamjuree"
 

--- a/Casks/font-barlow-condensed.rb
+++ b/Casks/font-barlow-condensed.rb
@@ -2,9 +2,10 @@ cask "font-barlow-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/barlowcondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/barlowcondensed"
   name "Barlow Condensed"
   homepage "https://fonts.google.com/specimen/Barlow+Condensed"
 

--- a/Casks/font-barlow-semi-condensed.rb
+++ b/Casks/font-barlow-semi-condensed.rb
@@ -2,9 +2,10 @@ cask "font-barlow-semi-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/barlowsemicondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/barlowsemicondensed"
   name "Barlow Semi Condensed"
   homepage "https://fonts.google.com/specimen/Barlow+Semi+Condensed"
 

--- a/Casks/font-baskervville.rb
+++ b/Casks/font-baskervville.rb
@@ -2,9 +2,10 @@ cask "font-baskervville" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/baskervville",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/baskervville"
   name "Baskervville"
   homepage "https://fonts.google.com/specimen/Baskervville"
 

--- a/Casks/font-battambang.rb
+++ b/Casks/font-battambang.rb
@@ -2,9 +2,10 @@ cask "font-battambang" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/battambang",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/battambang"
   name "Battambang"
   homepage "https://fonts.google.com/specimen/Battambang"
 

--- a/Casks/font-be-vietnam-pro.rb
+++ b/Casks/font-be-vietnam-pro.rb
@@ -2,9 +2,10 @@ cask "font-be-vietnam-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bevietnampro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bevietnampro"
   name "Be Vietnam Pro"
   desc "Well suited to tech companies and startups"
   homepage "https://fonts.google.com/specimen/Be+Vietnam+Pro"

--- a/Casks/font-bellota-text.rb
+++ b/Casks/font-bellota-text.rb
@@ -2,9 +2,10 @@ cask "font-bellota-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bellotatext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bellotatext"
   name "Bellota Text"
   homepage "https://fonts.google.com/specimen/Bellota+Text"
 

--- a/Casks/font-bellota.rb
+++ b/Casks/font-bellota.rb
@@ -2,9 +2,10 @@ cask "font-bellota" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bellota",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bellota"
   name "Bellota"
   homepage "https://fonts.google.com/specimen/Bellota"
 

--- a/Casks/font-benchnine.rb
+++ b/Casks/font-benchnine.rb
@@ -2,9 +2,10 @@ cask "font-benchnine" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/benchnine",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/benchnine"
   name "BenchNine"
   homepage "https://fonts.google.com/specimen/BenchNine"
 

--- a/Casks/font-besley.rb
+++ b/Casks/font-besley.rb
@@ -2,9 +2,10 @@ cask "font-besley" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/besley",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/besley"
   name "Besley"
   desc "Designed by owen earl (indestructible type*)"
   homepage "https://fonts.google.com/specimen/Besley"

--- a/Casks/font-bevan.rb
+++ b/Casks/font-bevan.rb
@@ -2,9 +2,10 @@ cask "font-bevan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bevan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bevan"
   name "Bevan"
   homepage "https://fonts.google.com/specimen/Bevan"
 

--- a/Casks/font-bio-rhyme-expanded.rb
+++ b/Casks/font-bio-rhyme-expanded.rb
@@ -2,9 +2,10 @@ cask "font-bio-rhyme-expanded" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/biorhymeexpanded",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/biorhymeexpanded"
   name "Bio Rhyme Expanded"
   homepage "https://fonts.google.com/specimen/Bio+Rhyme+Expanded"
 

--- a/Casks/font-bio-rhyme.rb
+++ b/Casks/font-bio-rhyme.rb
@@ -2,9 +2,10 @@ cask "font-bio-rhyme" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/biorhyme",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/biorhyme"
   name "Bio Rhyme"
   homepage "https://fonts.google.com/specimen/Bio+Rhyme"
 

--- a/Casks/font-birthstone-bounce.rb
+++ b/Casks/font-birthstone-bounce.rb
@@ -2,9 +2,10 @@ cask "font-birthstone-bounce" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/birthstonebounce",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/birthstonebounce"
   name "Birthstone Bounce"
   desc "Sibling family of birthstone that adds more luster and playfulness to it"
   homepage "https://fonts.google.com/specimen/Birthstone+Bounce"

--- a/Casks/font-biryani.rb
+++ b/Casks/font-biryani.rb
@@ -2,9 +2,10 @@ cask "font-biryani" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/biryani",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/biryani"
   name "Biryani"
   homepage "https://fonts.google.com/specimen/Biryani"
 

--- a/Casks/font-bitter.rb
+++ b/Casks/font-bitter.rb
@@ -2,9 +2,10 @@ cask "font-bitter" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bitter",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bitter"
   name "Bitter"
   desc "Slab-serif typeface optimized for e-ink screens"
   homepage "https://fonts.google.com/specimen/Bitter"

--- a/Casks/font-biz-udgothic.rb
+++ b/Casks/font-biz-udgothic.rb
@@ -2,9 +2,10 @@ cask "font-biz-udgothic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bizudgothic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bizudgothic"
   name "BIZ UDGothic"
   homepage "https://fonts.google.com/specimen/BIZ+UDGothic"
 

--- a/Casks/font-biz-udpgothic.rb
+++ b/Casks/font-biz-udpgothic.rb
@@ -2,9 +2,10 @@ cask "font-biz-udpgothic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bizudpgothic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bizudpgothic"
   name "BIZ UDPGothic"
   homepage "https://fonts.google.com/specimen/BIZ+UDPGothic"
 

--- a/Casks/font-blinker.rb
+++ b/Casks/font-blinker.rb
@@ -2,9 +2,10 @@ cask "font-blinker" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/blinker",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/blinker"
   name "Blinker"
   homepage "https://fonts.google.com/specimen/Blinker"
 

--- a/Casks/font-bona-nova.rb
+++ b/Casks/font-bona-nova.rb
@@ -2,9 +2,10 @@ cask "font-bona-nova" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/bonanova",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/bonanova"
   name "Bona Nova"
   desc "Cursive typeface"
   homepage "https://fonts.google.com/specimen/Bona+Nova"

--- a/Casks/font-brawler.rb
+++ b/Casks/font-brawler.rb
@@ -2,9 +2,10 @@ cask "font-brawler" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/brawler",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/brawler"
   name "Brawler"
   homepage "https://fonts.google.com/specimen/Brawler"
 

--- a/Casks/font-brygada-1918.rb
+++ b/Casks/font-brygada-1918.rb
@@ -2,9 +2,10 @@ cask "font-brygada-1918" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/brygada1918",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/brygada1918"
   name "Brygada 1918"
   desc "Available on the project's website"
   homepage "https://fonts.google.com/specimen/Brygada+1918"

--- a/Casks/font-buenard.rb
+++ b/Casks/font-buenard.rb
@@ -2,9 +2,10 @@ cask "font-buenard" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/buenard",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/buenard"
   name "Buenard"
   homepage "https://fonts.google.com/specimen/Buenard"
 

--- a/Casks/font-cabin-condensed.rb
+++ b/Casks/font-cabin-condensed.rb
@@ -2,9 +2,10 @@ cask "font-cabin-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cabincondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cabincondensed"
   name "Cabin Condensed"
   homepage "https://fonts.google.com/specimen/Cabin+Condensed"
 

--- a/Casks/font-cabin-sketch.rb
+++ b/Casks/font-cabin-sketch.rb
@@ -2,9 +2,10 @@ cask "font-cabin-sketch" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cabinsketch",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cabinsketch"
   name "Cabin Sketch"
   homepage "https://fonts.google.com/specimen/Cabin+Sketch"
 

--- a/Casks/font-cabin.rb
+++ b/Casks/font-cabin.rb
@@ -2,9 +2,10 @@ cask "font-cabin" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cabin",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cabin"
   name "Cabin"
   homepage "https://fonts.google.com/specimen/Cabin"
 

--- a/Casks/font-caladea.rb
+++ b/Casks/font-caladea.rb
@@ -2,9 +2,10 @@ cask "font-caladea" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/caladea",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/caladea"
   name "Caladea"
   homepage "https://fonts.google.com/specimen/Caladea"
 

--- a/Casks/font-cambay.rb
+++ b/Casks/font-cambay.rb
@@ -2,9 +2,10 @@ cask "font-cambay" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cambay",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cambay"
   name "Cambay"
   homepage "https://fonts.google.com/specimen/Cambay"
 

--- a/Casks/font-cantarell.rb
+++ b/Casks/font-cantarell.rb
@@ -2,9 +2,10 @@ cask "font-cantarell" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cantarell",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cantarell"
   name "Cantarell"
   homepage "https://fonts.google.com/specimen/Cantarell"
 

--- a/Casks/font-castoro.rb
+++ b/Casks/font-castoro.rb
@@ -2,9 +2,10 @@ cask "font-castoro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/castoro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/castoro"
   name "Castoro"
   desc "Named for the north american beaver, castor canadensis"
   homepage "https://fonts.google.com/specimen/Castoro"

--- a/Casks/font-caudex.rb
+++ b/Casks/font-caudex.rb
@@ -2,9 +2,10 @@ cask "font-caudex" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/caudex",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/caudex"
   name "Caudex"
   homepage "https://fonts.google.com/specimen/Caudex"
 

--- a/Casks/font-chakra-petch.rb
+++ b/Casks/font-chakra-petch.rb
@@ -2,9 +2,10 @@ cask "font-chakra-petch" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/chakrapetch",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/chakrapetch"
   name "Chakra Petch"
   homepage "https://fonts.google.com/specimen/Chakra+Petch"
 

--- a/Casks/font-changa-one.rb
+++ b/Casks/font-changa-one.rb
@@ -2,9 +2,10 @@ cask "font-changa-one" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/changaone",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/changaone"
   name "Changa One"
   homepage "https://fonts.google.com/specimen/Changa+One"
 

--- a/Casks/font-charm.rb
+++ b/Casks/font-charm.rb
@@ -2,9 +2,10 @@ cask "font-charm" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/charm",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/charm"
   name "Charm"
   homepage "https://fonts.google.com/specimen/Charm"
 

--- a/Casks/font-charmonman.rb
+++ b/Casks/font-charmonman.rb
@@ -2,9 +2,10 @@ cask "font-charmonman" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/charmonman",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/charmonman"
   name "Charmonman"
   homepage "https://fonts.google.com/specimen/Charmonman"
 

--- a/Casks/font-chathura.rb
+++ b/Casks/font-chathura.rb
@@ -2,9 +2,10 @@ cask "font-chathura" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/chathura",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/chathura"
   name "Chathura"
   homepage "https://fonts.google.com/specimen/Chathura"
 

--- a/Casks/font-chau-philomene-one.rb
+++ b/Casks/font-chau-philomene-one.rb
@@ -2,9 +2,10 @@ cask "font-chau-philomene-one" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/chauphilomeneone",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/chauphilomeneone"
   name "Chau Philomene One"
   homepage "https://fonts.google.com/specimen/Chau+Philomene+One"
 

--- a/Casks/font-cherry-swash.rb
+++ b/Casks/font-cherry-swash.rb
@@ -2,9 +2,10 @@ cask "font-cherry-swash" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cherryswash",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cherryswash"
   name "Cherry Swash"
   homepage "https://fonts.google.com/specimen/Cherry+Swash"
 

--- a/Casks/font-chivo.rb
+++ b/Casks/font-chivo.rb
@@ -2,9 +2,10 @@ cask "font-chivo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/chivo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/chivo"
   name "Chivo"
   homepage "https://fonts.google.com/specimen/Chivo"
 

--- a/Casks/font-cinzel-decorative.rb
+++ b/Casks/font-cinzel-decorative.rb
@@ -2,9 +2,10 @@ cask "font-cinzel-decorative" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cinzeldecorative",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cinzeldecorative"
   name "Cinzel Decorative"
   homepage "https://fonts.google.com/specimen/Cinzel+Decorative"
 

--- a/Casks/font-coda.rb
+++ b/Casks/font-coda.rb
@@ -2,9 +2,10 @@ cask "font-coda" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/coda",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/coda"
   name "Coda"
   homepage "https://fonts.google.com/specimen/Coda"
 

--- a/Casks/font-codystar.rb
+++ b/Casks/font-codystar.rb
@@ -2,9 +2,10 @@ cask "font-codystar" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/codystar",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/codystar"
   name "Codystar"
   homepage "https://fonts.google.com/specimen/Codystar"
 

--- a/Casks/font-content.rb
+++ b/Casks/font-content.rb
@@ -2,9 +2,10 @@ cask "font-content" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/content",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/content"
   name "Content"
   homepage "https://fonts.google.com/specimen/Content"
 

--- a/Casks/font-corben.rb
+++ b/Casks/font-corben.rb
@@ -2,9 +2,10 @@ cask "font-corben" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/corben",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/corben"
   name "Corben"
   homepage "https://fonts.google.com/specimen/Corben"
 

--- a/Casks/font-corinthia.rb
+++ b/Casks/font-corinthia.rb
@@ -2,9 +2,10 @@ cask "font-corinthia" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/corinthia",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/corinthia"
   name "Corinthia"
   homepage "https://fonts.google.com/specimen/Corinthia"
 

--- a/Casks/font-cormorant-garamond.rb
+++ b/Casks/font-cormorant-garamond.rb
@@ -2,9 +2,10 @@ cask "font-cormorant-garamond" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cormorantgaramond",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cormorantgaramond"
   name "Cormorant Garamond"
   homepage "https://fonts.google.com/specimen/Cormorant+Garamond"
 

--- a/Casks/font-cormorant-infant.rb
+++ b/Casks/font-cormorant-infant.rb
@@ -2,9 +2,10 @@ cask "font-cormorant-infant" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cormorantinfant",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cormorantinfant"
   name "Cormorant Infant"
   homepage "https://fonts.google.com/specimen/Cormorant+Infant"
 

--- a/Casks/font-cormorant-sc.rb
+++ b/Casks/font-cormorant-sc.rb
@@ -2,9 +2,10 @@ cask "font-cormorant-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cormorantsc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cormorantsc"
   name "Cormorant SC"
   homepage "https://fonts.google.com/specimen/Cormorant+SC"
 

--- a/Casks/font-cormorant-unicase.rb
+++ b/Casks/font-cormorant-unicase.rb
@@ -2,9 +2,10 @@ cask "font-cormorant-unicase" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cormorantunicase",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cormorantunicase"
   name "Cormorant Unicase"
   homepage "https://fonts.google.com/specimen/Cormorant+Unicase"
 

--- a/Casks/font-cormorant-upright.rb
+++ b/Casks/font-cormorant-upright.rb
@@ -2,9 +2,10 @@ cask "font-cormorant-upright" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cormorantupright",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cormorantupright"
   name "Cormorant Upright"
   homepage "https://fonts.google.com/specimen/Cormorant+Upright"
 

--- a/Casks/font-cousine.rb
+++ b/Casks/font-cousine.rb
@@ -2,9 +2,10 @@ cask "font-cousine" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/cousine",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/cousine"
   name "Cousine"
   homepage "https://fonts.google.com/specimen/Cousine"
 

--- a/Casks/font-coustard.rb
+++ b/Casks/font-coustard.rb
@@ -2,9 +2,10 @@ cask "font-coustard" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/coustard",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/coustard"
   name "Coustard"
   homepage "https://fonts.google.com/specimen/Coustard"
 

--- a/Casks/font-crete-round.rb
+++ b/Casks/font-crete-round.rb
@@ -2,9 +2,10 @@ cask "font-crete-round" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/creteround",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/creteround"
   name "Crete Round"
   homepage "https://fonts.google.com/specimen/Crete+Round"
 

--- a/Casks/font-crimson-pro.rb
+++ b/Casks/font-crimson-pro.rb
@@ -2,9 +2,10 @@ cask "font-crimson-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/crimsonpro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/crimsonpro"
   name "Crimson Pro"
   homepage "https://fonts.google.com/specimen/Crimson+Pro"
 

--- a/Casks/font-crimson-text.rb
+++ b/Casks/font-crimson-text.rb
@@ -2,9 +2,10 @@ cask "font-crimson-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/crimsontext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/crimsontext"
   name "Crimson Text"
   homepage "https://fonts.google.com/specimen/Crimson+Text"
 

--- a/Casks/font-cuprum.rb
+++ b/Casks/font-cuprum.rb
@@ -2,9 +2,10 @@ cask "font-cuprum" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/cuprum",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/cuprum"
   name "Cuprum"
   homepage "https://fonts.google.com/specimen/Cuprum"
 

--- a/Casks/font-darker-grotesque.rb
+++ b/Casks/font-darker-grotesque.rb
@@ -2,9 +2,10 @@ cask "font-darker-grotesque" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/darkergrotesque",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/darkergrotesque"
   name "Darker Grotesque"
   homepage "https://fonts.google.com/specimen/Darker+Grotesque"
 

--- a/Casks/font-david-libre.rb
+++ b/Casks/font-david-libre.rb
@@ -2,9 +2,10 @@ cask "font-david-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/davidlibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/davidlibre"
   name "David Libre"
   desc "Led by meir sadan, a type designer based in tel aviv, israel"
   homepage "https://fonts.google.com/specimen/David+Libre"

--- a/Casks/font-delius-unicase.rb
+++ b/Casks/font-delius-unicase.rb
@@ -2,9 +2,10 @@ cask "font-delius-unicase" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/deliusunicase",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/deliusunicase"
   name "Delius Unicase"
   homepage "https://fonts.google.com/specimen/Delius+Unicase"
 

--- a/Casks/font-dhyana.rb
+++ b/Casks/font-dhyana.rb
@@ -2,9 +2,10 @@ cask "font-dhyana" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/dhyana",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/dhyana"
   name "Dhyana"
   homepage "https://fonts.google.com/specimen/Dhyana"
 

--- a/Casks/font-dm-mono.rb
+++ b/Casks/font-dm-mono.rb
@@ -2,9 +2,10 @@ cask "font-dm-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/dmmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/dmmono"
   name "DM Mono"
   homepage "https://fonts.google.com/specimen/DM+Mono"
 

--- a/Casks/font-dm-sans.rb
+++ b/Casks/font-dm-sans.rb
@@ -2,9 +2,10 @@ cask "font-dm-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/dmsans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/dmsans"
   name "DM Sans"
   homepage "https://fonts.google.com/specimen/DM+Sans"
 

--- a/Casks/font-dm-serif-display.rb
+++ b/Casks/font-dm-serif-display.rb
@@ -2,9 +2,10 @@ cask "font-dm-serif-display" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/dmserifdisplay",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/dmserifdisplay"
   name "DM Serif Display"
   homepage "https://fonts.google.com/specimen/DM+Serif+Display"
 

--- a/Casks/font-dm-serif-text.rb
+++ b/Casks/font-dm-serif-text.rb
@@ -2,9 +2,10 @@ cask "font-dm-serif-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/dmseriftext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/dmseriftext"
   name "DM Serif Text"
   homepage "https://fonts.google.com/specimen/DM+Serif+Text"
 

--- a/Casks/font-dongle.rb
+++ b/Casks/font-dongle.rb
@@ -2,9 +2,10 @@ cask "font-dongle" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/dongle",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/dongle"
   name "Dongle"
   homepage "https://fonts.google.com/specimen/Dongle"
 

--- a/Casks/font-economica.rb
+++ b/Casks/font-economica.rb
@@ -2,9 +2,10 @@ cask "font-economica" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/economica",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/economica"
   name "Economica"
   homepage "https://fonts.google.com/specimen/Economica"
 

--- a/Casks/font-ek-mukta.rb
+++ b/Casks/font-ek-mukta.rb
@@ -2,9 +2,10 @@ cask "font-ek-mukta" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ekmukta",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ekmukta"
   name "Ek Mukta"
   homepage "https://fonts.google.com/specimen/Ek+Mukta"
 

--- a/Casks/font-elsie-swash-caps.rb
+++ b/Casks/font-elsie-swash-caps.rb
@@ -2,9 +2,10 @@ cask "font-elsie-swash-caps" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/elsieswashcaps",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/elsieswashcaps"
   name "Elsie Swash Caps"
   homepage "https://fonts.google.com/specimen/Elsie+Swash+Caps"
 

--- a/Casks/font-elsie.rb
+++ b/Casks/font-elsie.rb
@@ -2,9 +2,10 @@ cask "font-elsie" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/elsie",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/elsie"
   name "Elsie"
   homepage "https://fonts.google.com/specimen/Elsie"
 

--- a/Casks/font-encode-sans-condensed.rb
+++ b/Casks/font-encode-sans-condensed.rb
@@ -2,9 +2,10 @@ cask "font-encode-sans-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/encodesanscondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/encodesanscondensed"
   name "Encode Sans Condensed"
   homepage "https://fonts.google.com/specimen/Encode+Sans+Condensed"
 

--- a/Casks/font-encode-sans-expanded.rb
+++ b/Casks/font-encode-sans-expanded.rb
@@ -2,9 +2,10 @@ cask "font-encode-sans-expanded" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/encodesansexpanded",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/encodesansexpanded"
   name "Encode Sans Expanded"
   homepage "https://fonts.google.com/specimen/Encode+Sans+Expanded"
 

--- a/Casks/font-encode-sans-semi-condensed.rb
+++ b/Casks/font-encode-sans-semi-condensed.rb
@@ -2,9 +2,10 @@ cask "font-encode-sans-semi-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/encodesanssemicondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/encodesanssemicondensed"
   name "Encode Sans Semi Condensed"
   homepage "https://fonts.google.com/specimen/Encode+Sans+Semi+Condensed"
 

--- a/Casks/font-encode-sans-semi-expanded.rb
+++ b/Casks/font-encode-sans-semi-expanded.rb
@@ -2,9 +2,10 @@ cask "font-encode-sans-semi-expanded" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/encodesanssemiexpanded",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/encodesanssemiexpanded"
   name "Encode Sans Semi Expanded"
   homepage "https://fonts.google.com/specimen/Encode+Sans+Semi+Expanded"
 

--- a/Casks/font-enriqueta.rb
+++ b/Casks/font-enriqueta.rb
@@ -2,9 +2,10 @@ cask "font-enriqueta" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/enriqueta",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/enriqueta"
   name "Enriqueta"
   homepage "https://fonts.google.com/specimen/Enriqueta"
 

--- a/Casks/font-epilogue.rb
+++ b/Casks/font-epilogue.rb
@@ -2,9 +2,10 @@ cask "font-epilogue" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/epilogue",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/epilogue"
   name "Epilogue"
   desc "Sans serif variable font with a weight axis"
   homepage "https://fonts.google.com/specimen/Epilogue"

--- a/Casks/font-exo-2.rb
+++ b/Casks/font-exo-2.rb
@@ -2,9 +2,10 @@ cask "font-exo-2" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/exo2",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/exo2"
   name "Exo 2"
   homepage "https://fonts.google.com/specimen/Exo+2"
 

--- a/Casks/font-exo.rb
+++ b/Casks/font-exo.rb
@@ -2,9 +2,10 @@ cask "font-exo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/exo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/exo"
   name "Exo"
   homepage "https://fonts.google.com/specimen/Exo"
 

--- a/Casks/font-expletus-sans.rb
+++ b/Casks/font-expletus-sans.rb
@@ -2,9 +2,10 @@ cask "font-expletus-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/expletussans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/expletussans"
   name "Expletus Sans"
   homepage "https://fonts.google.com/specimen/Expletus+Sans"
 

--- a/Casks/font-fahkwang.rb
+++ b/Casks/font-fahkwang.rb
@@ -2,9 +2,10 @@ cask "font-fahkwang" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/fahkwang",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/fahkwang"
   name "Fahkwang"
   homepage "https://fonts.google.com/specimen/Fahkwang"
 

--- a/Casks/font-familjen-grotesk.rb
+++ b/Casks/font-familjen-grotesk.rb
@@ -2,9 +2,10 @@ cask "font-familjen-grotesk" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/familjengrotesk",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/familjengrotesk"
   name "Familjen Grotesk"
   desc "Sans serif typeface with a contemporary appearance"
   homepage "https://fonts.google.com/specimen/Familjen+Grotesk"

--- a/Casks/font-fanwood-text.rb
+++ b/Casks/font-fanwood-text.rb
@@ -2,9 +2,10 @@ cask "font-fanwood-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/fanwoodtext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/fanwoodtext"
   name "Fanwood Text"
   homepage "https://fonts.google.com/specimen/Fanwood+Text"
 

--- a/Casks/font-farro.rb
+++ b/Casks/font-farro.rb
@@ -2,9 +2,10 @@ cask "font-farro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/farro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/farro"
   name "Farro"
   homepage "https://fonts.google.com/specimen/Farro"
 

--- a/Casks/font-faustina.rb
+++ b/Casks/font-faustina.rb
@@ -2,9 +2,10 @@ cask "font-faustina" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/faustina",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/faustina"
   name "Faustina"
   homepage "https://fonts.google.com/specimen/Faustina"
 

--- a/Casks/font-finlandica.rb
+++ b/Casks/font-finlandica.rb
@@ -2,9 +2,10 @@ cask "font-finlandica" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/finlandica",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/finlandica"
   name "Finlandica"
   homepage "https://fonts.google.com/specimen/Finlandica"
 

--- a/Casks/font-fira-sans-condensed.rb
+++ b/Casks/font-fira-sans-condensed.rb
@@ -2,9 +2,10 @@ cask "font-fira-sans-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/firasanscondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/firasanscondensed"
   name "Fira Sans Condensed"
   homepage "https://fonts.google.com/specimen/Fira+Sans+Condensed"
 

--- a/Casks/font-fira-sans-extra-condensed.rb
+++ b/Casks/font-fira-sans-extra-condensed.rb
@@ -2,9 +2,10 @@ cask "font-fira-sans-extra-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/firasansextracondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/firasansextracondensed"
   name "Fira Sans Extra Condensed"
   homepage "https://fonts.google.com/specimen/Fira+Sans+Extra+Condensed"
 

--- a/Casks/font-flamenco.rb
+++ b/Casks/font-flamenco.rb
@@ -2,9 +2,10 @@ cask "font-flamenco" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/flamenco",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/flamenco"
   name "Flamenco"
   homepage "https://fonts.google.com/specimen/Flamenco"
 

--- a/Casks/font-fondamento.rb
+++ b/Casks/font-fondamento.rb
@@ -2,9 +2,10 @@ cask "font-fondamento" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/fondamento",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/fondamento"
   name "Fondamento"
   homepage "https://fonts.google.com/specimen/Fondamento"
 

--- a/Casks/font-frank-ruhl-libre.rb
+++ b/Casks/font-frank-ruhl-libre.rb
@@ -2,9 +2,10 @@ cask "font-frank-ruhl-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/frankruhllibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/frankruhllibre"
   name "Frank Ruhl Libre"
   homepage "https://fonts.google.com/specimen/Frank+Ruhl+Libre"
 

--- a/Casks/font-fraunces.rb
+++ b/Casks/font-fraunces.rb
@@ -2,9 +2,10 @@ cask "font-fraunces" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/fraunces",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/fraunces"
   name "Fraunces"
   desc "Display, old style soft-serif typeface"
   homepage "https://fonts.google.com/specimen/Fraunces"

--- a/Casks/font-fruktur.rb
+++ b/Casks/font-fruktur.rb
@@ -2,9 +2,10 @@ cask "font-fruktur" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/fruktur",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/fruktur"
   name "Fruktur"
   homepage "https://fonts.google.com/specimen/Fruktur"
 

--- a/Casks/font-fuzzy-bubbles.rb
+++ b/Casks/font-fuzzy-bubbles.rb
@@ -2,9 +2,10 @@ cask "font-fuzzy-bubbles" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/fuzzybubbles",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/fuzzybubbles"
   name "Fuzzy Bubbles"
   desc "Perfect for children's parties"
   homepage "https://fonts.google.com/specimen/Fuzzy+Bubbles"

--- a/Casks/font-gaegu.rb
+++ b/Casks/font-gaegu.rb
@@ -2,9 +2,10 @@ cask "font-gaegu" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gaegu",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gaegu"
   name "Gaegu"
   homepage "https://fonts.google.com/specimen/Gaegu"
 

--- a/Casks/font-gantari.rb
+++ b/Casks/font-gantari.rb
@@ -2,9 +2,10 @@ cask "font-gantari" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gantari",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gantari"
   name "Gantari"
   desc "Designed so that all characters can look harmonious"
   homepage "https://fonts.google.com/specimen/Gantari"

--- a/Casks/font-gayathri.rb
+++ b/Casks/font-gayathri.rb
@@ -2,9 +2,10 @@ cask "font-gayathri" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gayathri",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gayathri"
   name "Gayathri"
   homepage "https://fonts.google.com/specimen/Gayathri"
 

--- a/Casks/font-gelasio.rb
+++ b/Casks/font-gelasio.rb
@@ -2,9 +2,10 @@ cask "font-gelasio" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gelasio",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gelasio"
   name "Gelasio"
   homepage "https://fonts.google.com/specimen/Gelasio"
 

--- a/Casks/font-genos.rb
+++ b/Casks/font-genos.rb
@@ -2,9 +2,10 @@ cask "font-genos" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/genos",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/genos"
   name "Genos"
   desc "Modern display font with a futuristic feel"
   homepage "https://fonts.google.com/specimen/Genos"

--- a/Casks/font-gentium-book-plus.rb
+++ b/Casks/font-gentium-book-plus.rb
@@ -2,9 +2,10 @@ cask "font-gentium-book-plus" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gentiumbookplus",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gentiumbookplus"
   name "Gentium Book Plus"
   desc "New version of the reduced character set families, gentium book basic"
   homepage "https://fonts.google.com/specimen/Gentium+Book+Plus"

--- a/Casks/font-geo.rb
+++ b/Casks/font-geo.rb
@@ -2,9 +2,10 @@ cask "font-geo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/geo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/geo"
   name "Geo"
   homepage "https://fonts.google.com/specimen/Geo"
 

--- a/Casks/font-georama.rb
+++ b/Casks/font-georama.rb
@@ -2,9 +2,10 @@ cask "font-georama" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/georama",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/georama"
   name "Georama"
   desc "Original typeface available in several widths and weights"
   homepage "https://fonts.google.com/specimen/Georama"

--- a/Casks/font-gfs-neohellenic.rb
+++ b/Casks/font-gfs-neohellenic.rb
@@ -2,9 +2,10 @@ cask "font-gfs-neohellenic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gfsneohellenic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gfsneohellenic"
   name "GFS Neohellenic"
   homepage "https://fonts.google.com/specimen/GFS+Neohellenic"
 

--- a/Casks/font-glegoo.rb
+++ b/Casks/font-glegoo.rb
@@ -2,9 +2,10 @@ cask "font-glegoo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/glegoo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/glegoo"
   name "Glegoo"
   homepage "https://fonts.google.com/specimen/Glegoo"
 

--- a/Casks/font-glory.rb
+++ b/Casks/font-glory.rb
@@ -2,9 +2,10 @@ cask "font-glory" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/glory",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/glory"
   name "Glory"
   desc "Suitable for logos, headlines and body text with the available six weights"
   homepage "https://fonts.google.com/specimen/Glory"

--- a/Casks/font-goldman.rb
+++ b/Casks/font-goldman.rb
@@ -2,9 +2,10 @@ cask "font-goldman" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/goldman",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/goldman"
   name "Goldman"
   desc "Latin display typeface designed for posters"
   homepage "https://fonts.google.com/specimen/Goldman"

--- a/Casks/font-gorditas.rb
+++ b/Casks/font-gorditas.rb
@@ -2,9 +2,10 @@ cask "font-gorditas" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gorditas",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gorditas"
   name "Gorditas"
   homepage "https://fonts.google.com/specimen/Gorditas"
 

--- a/Casks/font-gothic-a1.rb
+++ b/Casks/font-gothic-a1.rb
@@ -2,9 +2,10 @@ cask "font-gothic-a1" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gothica1",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gothica1"
   name "Gothic A1"
   homepage "https://fonts.google.com/specimen/Gothic+A1"
 

--- a/Casks/font-gowun-batang.rb
+++ b/Casks/font-gowun-batang.rb
@@ -2,9 +2,10 @@ cask "font-gowun-batang" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gowunbatang",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gowunbatang"
   name "Gowun Batang"
   homepage "https://fonts.google.com/specimen/Gowun+Batang"
 

--- a/Casks/font-grandstander.rb
+++ b/Casks/font-grandstander.rb
@@ -2,9 +2,10 @@ cask "font-grandstander" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/grandstander",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/grandstander"
   name "Grandstander"
   desc "Display variable font with a weight axis"
   homepage "https://fonts.google.com/specimen/Grandstander"

--- a/Casks/font-grenze.rb
+++ b/Casks/font-grenze.rb
@@ -2,9 +2,10 @@ cask "font-grenze" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/grenze",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/grenze"
   name "Grenze"
   homepage "https://fonts.google.com/specimen/Grenze"
 

--- a/Casks/font-gudea.rb
+++ b/Casks/font-gudea.rb
@@ -2,9 +2,10 @@ cask "font-gudea" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gudea",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gudea"
   name "Gudea"
   homepage "https://fonts.google.com/specimen/Gudea"
 

--- a/Casks/font-gupter.rb
+++ b/Casks/font-gupter.rb
@@ -2,9 +2,10 @@ cask "font-gupter" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gupter",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gupter"
   name "Gupter"
   homepage "https://fonts.google.com/specimen/Gupter"
 

--- a/Casks/font-gwendolyn.rb
+++ b/Casks/font-gwendolyn.rb
@@ -2,9 +2,10 @@ cask "font-gwendolyn" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/gwendolyn",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/gwendolyn"
   name "Gwendolyn"
   homepage "https://fonts.google.com/specimen/Gwendolyn"
 

--- a/Casks/font-hanuman.rb
+++ b/Casks/font-hanuman.rb
@@ -2,9 +2,10 @@ cask "font-hanuman" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hanuman",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hanuman"
   name "Hanuman"
   homepage "https://fonts.google.com/specimen/Hanuman"
 

--- a/Casks/font-harmattan.rb
+++ b/Casks/font-harmattan.rb
@@ -2,9 +2,10 @@ cask "font-harmattan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/harmattan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/harmattan"
   name "Harmattan"
   homepage "https://fonts.google.com/specimen/Harmattan"
 

--- a/Casks/font-hind-colombo.rb
+++ b/Casks/font-hind-colombo.rb
@@ -2,9 +2,10 @@ cask "font-hind-colombo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindcolombo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindcolombo"
   name "Hind Colombo"
   homepage "https://fonts.google.com/specimen/Hind+Colombo"
 

--- a/Casks/font-hind-guntur.rb
+++ b/Casks/font-hind-guntur.rb
@@ -2,9 +2,10 @@ cask "font-hind-guntur" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindguntur",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindguntur"
   name "Hind Guntur"
   homepage "https://fonts.google.com/specimen/Hind+Guntur"
 

--- a/Casks/font-hind-jalandhar.rb
+++ b/Casks/font-hind-jalandhar.rb
@@ -2,9 +2,10 @@ cask "font-hind-jalandhar" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindjalandhar",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindjalandhar"
   name "Hind Jalandhar"
   homepage "https://fonts.google.com/specimen/Hind+Jalandhar"
 

--- a/Casks/font-hind-kochi.rb
+++ b/Casks/font-hind-kochi.rb
@@ -2,9 +2,10 @@ cask "font-hind-kochi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindkochi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindkochi"
   name "Hind Kochi"
   homepage "https://fonts.google.com/specimen/Hind+Kochi"
 

--- a/Casks/font-hind-madurai.rb
+++ b/Casks/font-hind-madurai.rb
@@ -2,9 +2,10 @@ cask "font-hind-madurai" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindmadurai",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindmadurai"
   name "Hind Madurai"
   homepage "https://fonts.google.com/specimen/Hind+Madurai"
 

--- a/Casks/font-hind-mysuru.rb
+++ b/Casks/font-hind-mysuru.rb
@@ -2,9 +2,10 @@ cask "font-hind-mysuru" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindmysuru",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindmysuru"
   name "Hind Mysuru"
   homepage "https://fonts.google.com/specimen/Hind+Mysuru"
 

--- a/Casks/font-hind-siliguri.rb
+++ b/Casks/font-hind-siliguri.rb
@@ -2,9 +2,10 @@ cask "font-hind-siliguri" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindsiliguri",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindsiliguri"
   name "Hind Siliguri"
   homepage "https://fonts.google.com/specimen/Hind+Siliguri"
 

--- a/Casks/font-hind-vadodara.rb
+++ b/Casks/font-hind-vadodara.rb
@@ -2,9 +2,10 @@ cask "font-hind-vadodara" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/hindvadodara",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/hindvadodara"
   name "Hind Vadodara"
   homepage "https://fonts.google.com/specimen/Hind+Vadodara"
 

--- a/Casks/font-ibarra-real-nova.rb
+++ b/Casks/font-ibarra-real-nova.rb
@@ -2,9 +2,10 @@ cask "font-ibarra-real-nova" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibarrarealnova",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibarrarealnova"
   name "Ibarra Real Nova"
   homepage "https://fonts.google.com/specimen/Ibarra+Real+Nova"
 

--- a/Casks/font-ibm-plex-mono.rb
+++ b/Casks/font-ibm-plex-mono.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexmono"
   name "IBM Plex Mono"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Mono"
 

--- a/Casks/font-ibm-plex-sans-arabic.rb
+++ b/Casks/font-ibm-plex-sans-arabic.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-arabic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsansarabic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsansarabic"
   name "IBM Plex Sans Arabic"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+Arabic"
 

--- a/Casks/font-ibm-plex-sans-condensed.rb
+++ b/Casks/font-ibm-plex-sans-condensed.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsanscondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsanscondensed"
   name "IBM Plex Sans Condensed"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+Condensed"
 

--- a/Casks/font-ibm-plex-sans-devanagari.rb
+++ b/Casks/font-ibm-plex-sans-devanagari.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-devanagari" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsansdevanagari",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsansdevanagari"
   name "IBM Plex Sans Devanagari"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+Devanagari"
 

--- a/Casks/font-ibm-plex-sans-hebrew.rb
+++ b/Casks/font-ibm-plex-sans-hebrew.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-hebrew" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsanshebrew",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsanshebrew"
   name "IBM Plex Sans Hebrew"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+Hebrew"
 

--- a/Casks/font-ibm-plex-sans-kr.rb
+++ b/Casks/font-ibm-plex-sans-kr.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-kr" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsanskr",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsanskr"
   name "IBM Plex Sans KR"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+KR"
 

--- a/Casks/font-ibm-plex-sans-thai-looped.rb
+++ b/Casks/font-ibm-plex-sans-thai-looped.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-thai-looped" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsansthailooped",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsansthailooped"
   name "IBM Plex Sans Thai Looped"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+Thai+Looped"
 

--- a/Casks/font-ibm-plex-sans-thai.rb
+++ b/Casks/font-ibm-plex-sans-thai.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans-thai" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsansthai",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsansthai"
   name "IBM Plex Sans Thai"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans+Thai"
 

--- a/Casks/font-ibm-plex-sans.rb
+++ b/Casks/font-ibm-plex-sans.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexsans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexsans"
   name "IBM Plex Sans"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Sans"
 

--- a/Casks/font-ibm-plex-serif.rb
+++ b/Casks/font-ibm-plex-serif.rb
@@ -2,9 +2,10 @@ cask "font-ibm-plex-serif" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ibmplexserif",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ibmplexserif"
   name "IBM Plex Serif"
   homepage "https://fonts.google.com/specimen/IBM+Plex+Serif"
 

--- a/Casks/font-im-fell-double-pica.rb
+++ b/Casks/font-im-fell-double-pica.rb
@@ -2,9 +2,10 @@ cask "font-im-fell-double-pica" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/imfelldoublepica",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/imfelldoublepica"
   name "IM Fell Double Pica"
   homepage "https://fonts.google.com/specimen/IM+Fell+Double+Pica"
 

--- a/Casks/font-im-fell-dw-pica.rb
+++ b/Casks/font-im-fell-dw-pica.rb
@@ -2,9 +2,10 @@ cask "font-im-fell-dw-pica" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/imfelldwpica",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/imfelldwpica"
   name "IM Fell DW Pica"
   homepage "https://fonts.google.com/specimen/IM+Fell+DW+Pica"
 

--- a/Casks/font-im-fell-english.rb
+++ b/Casks/font-im-fell-english.rb
@@ -2,9 +2,10 @@ cask "font-im-fell-english" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/imfellenglish",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/imfellenglish"
   name "IM Fell English"
   homepage "https://fonts.google.com/specimen/IM+Fell+English"
 

--- a/Casks/font-im-fell-french-canon.rb
+++ b/Casks/font-im-fell-french-canon.rb
@@ -2,9 +2,10 @@ cask "font-im-fell-french-canon" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/imfellfrenchcanon",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/imfellfrenchcanon"
   name "IM Fell French Canon"
   homepage "https://fonts.google.com/specimen/IM+Fell+French+Canon"
 

--- a/Casks/font-im-fell-great-primer.rb
+++ b/Casks/font-im-fell-great-primer.rb
@@ -2,9 +2,10 @@ cask "font-im-fell-great-primer" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/imfellgreatprimer",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/imfellgreatprimer"
   name "IM Fell Great Primer"
   homepage "https://fonts.google.com/specimen/IM+Fell+Great+Primer"
 

--- a/Casks/font-inika.rb
+++ b/Casks/font-inika.rb
@@ -2,9 +2,10 @@ cask "font-inika" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/inika",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/inika"
   name "Inika"
   homepage "https://fonts.google.com/specimen/Inika"
 

--- a/Casks/font-inknut-antiqua.rb
+++ b/Casks/font-inknut-antiqua.rb
@@ -2,9 +2,10 @@ cask "font-inknut-antiqua" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/inknutantiqua",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/inknutantiqua"
   name "Inknut Antiqua"
   homepage "https://fonts.google.com/specimen/Inknut+Antiqua"
 

--- a/Casks/font-inria-sans.rb
+++ b/Casks/font-inria-sans.rb
@@ -2,9 +2,10 @@ cask "font-inria-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/inriasans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/inriasans"
   name "Inria Sans"
   homepage "https://fonts.google.com/specimen/Inria+Sans"
 

--- a/Casks/font-inria-serif.rb
+++ b/Casks/font-inria-serif.rb
@@ -2,9 +2,10 @@ cask "font-inria-serif" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/inriaserif",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/inriaserif"
   name "Inria Serif"
   homepage "https://fonts.google.com/specimen/Inria+Serif"
 

--- a/Casks/font-inter-tight.rb
+++ b/Casks/font-inter-tight.rb
@@ -2,9 +2,10 @@ cask "font-inter-tight" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/intertight",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/intertight"
   name "Inter Tight"
   homepage "https://fonts.google.com/specimen/Inter+Tight"
 

--- a/Casks/font-istok-web.rb
+++ b/Casks/font-istok-web.rb
@@ -2,9 +2,10 @@ cask "font-istok-web" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/istokweb",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/istokweb"
   name "Istok Web"
   homepage "https://fonts.google.com/specimen/Istok+Web"
 

--- a/Casks/font-jaldi.rb
+++ b/Casks/font-jaldi.rb
@@ -2,9 +2,10 @@ cask "font-jaldi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/jaldi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/jaldi"
   name "Jaldi"
   homepage "https://fonts.google.com/specimen/Jaldi"
 

--- a/Casks/font-josefin-sans.rb
+++ b/Casks/font-josefin-sans.rb
@@ -2,9 +2,10 @@ cask "font-josefin-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/josefinsans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/josefinsans"
   name "Josefin Sans"
   homepage "https://fonts.google.com/specimen/Josefin+Sans"
 

--- a/Casks/font-josefin-slab.rb
+++ b/Casks/font-josefin-slab.rb
@@ -2,9 +2,10 @@ cask "font-josefin-slab" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/josefinslab",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/josefinslab"
   name "Josefin Slab"
   homepage "https://fonts.google.com/specimen/Josefin+Slab"
 

--- a/Casks/font-jost.rb
+++ b/Casks/font-jost.rb
@@ -2,9 +2,10 @@ cask "font-jost" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/jost",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/jost"
   name "Jost"
   homepage "https://fonts.google.com/specimen/Jost"
 

--- a/Casks/font-judson.rb
+++ b/Casks/font-judson.rb
@@ -2,9 +2,10 @@ cask "font-judson" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/judson",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/judson"
   name "Judson"
   homepage "https://fonts.google.com/specimen/Judson"
 

--- a/Casks/font-k2d.rb
+++ b/Casks/font-k2d.rb
@@ -2,9 +2,10 @@ cask "font-k2d" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/k2d",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/k2d"
   name "K2D"
   homepage "https://fonts.google.com/specimen/K2D"
 

--- a/Casks/font-kadwa.rb
+++ b/Casks/font-kadwa.rb
@@ -2,9 +2,10 @@ cask "font-kadwa" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kadwa",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kadwa"
   name "Kadwa"
   homepage "https://fonts.google.com/specimen/Kadwa"
 

--- a/Casks/font-kaisei-decol.rb
+++ b/Casks/font-kaisei-decol.rb
@@ -2,9 +2,10 @@ cask "font-kaisei-decol" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kaiseidecol",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kaiseidecol"
   name "Kaisei Decol"
   desc "Designed with the same element in kanji, the little dot at the end of the stroke"
   homepage "https://fonts.google.com/specimen/Kaisei+Decol"

--- a/Casks/font-kaisei-harunoumi.rb
+++ b/Casks/font-kaisei-harunoumi.rb
@@ -2,9 +2,10 @@ cask "font-kaisei-harunoumi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kaiseiharunoumi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kaiseiharunoumi"
   name "Kaisei HarunoUmi"
   homepage "https://fonts.google.com/specimen/Kaisei+HarunoUmi"
 

--- a/Casks/font-kaisei-opti.rb
+++ b/Casks/font-kaisei-opti.rb
@@ -2,9 +2,10 @@ cask "font-kaisei-opti" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kaiseiopti",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kaiseiopti"
   name "Kaisei Opti"
   desc "Modern style japanese typeface"
   homepage "https://fonts.google.com/specimen/Kaisei+Opti"

--- a/Casks/font-kaisei-tokumin.rb
+++ b/Casks/font-kaisei-tokumin.rb
@@ -2,9 +2,10 @@ cask "font-kaisei-tokumin" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kaiseitokumin",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kaiseitokumin"
   name "Kaisei Tokumin"
   desc "Designed to keep the legibility and still have power as an extra bold typeface"
   homepage "https://fonts.google.com/specimen/Kaisei+Tokumin"

--- a/Casks/font-kameron.rb
+++ b/Casks/font-kameron.rb
@@ -2,9 +2,10 @@ cask "font-kameron" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kameron",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kameron"
   name "Kameron"
   homepage "https://fonts.google.com/specimen/Kameron"
 

--- a/Casks/font-kanit.rb
+++ b/Casks/font-kanit.rb
@@ -2,9 +2,10 @@ cask "font-kanit" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kanit",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kanit"
   name "Kanit"
   homepage "https://fonts.google.com/specimen/Kanit"
 

--- a/Casks/font-kantumruy-pro.rb
+++ b/Casks/font-kantumruy-pro.rb
@@ -2,9 +2,10 @@ cask "font-kantumruy-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kantumruypro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kantumruypro"
   name "Kantumruy Pro"
   desc "From work sans, with modified width and weight"
   homepage "https://fonts.google.com/specimen/Kantumruy+Pro"

--- a/Casks/font-kantumruy.rb
+++ b/Casks/font-kantumruy.rb
@@ -2,9 +2,10 @@ cask "font-kantumruy" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kantumruy",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kantumruy"
   name "Kantumruy"
   homepage "https://fonts.google.com/specimen/Kantumruy"
 

--- a/Casks/font-karantina.rb
+++ b/Casks/font-karantina.rb
@@ -2,9 +2,10 @@ cask "font-karantina" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/karantina",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/karantina"
   name "Karantina"
   desc "Three weight family that includes - light, regular and bold"
   homepage "https://fonts.google.com/specimen/Karantina"

--- a/Casks/font-karla-tamil-inclined.rb
+++ b/Casks/font-karla-tamil-inclined.rb
@@ -2,9 +2,10 @@ cask "font-karla-tamil-inclined" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/karlatamilinclined",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/karlatamilinclined"
   name "Karla Tamil Inclined"
   homepage "https://fonts.google.com/specimen/Karla+Tamil+Inclined"
 

--- a/Casks/font-karla-tamil-upright.rb
+++ b/Casks/font-karla-tamil-upright.rb
@@ -2,9 +2,10 @@ cask "font-karla-tamil-upright" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/karlatamilupright",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/karlatamilupright"
   name "Karla Tamil Upright"
   homepage "https://fonts.google.com/specimen/Karla+Tamil+Upright"
 

--- a/Casks/font-karla.rb
+++ b/Casks/font-karla.rb
@@ -2,9 +2,10 @@ cask "font-karla" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/karla",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/karla"
   name "Karla"
   homepage "https://fonts.google.com/specimen/Karla"
 

--- a/Casks/font-khand.rb
+++ b/Casks/font-khand.rb
@@ -2,9 +2,10 @@ cask "font-khand" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/khand",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/khand"
   name "Khand"
   homepage "https://fonts.google.com/specimen/Khand"
 

--- a/Casks/font-khula.rb
+++ b/Casks/font-khula.rb
@@ -2,9 +2,10 @@ cask "font-khula" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/khula",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/khula"
   name "Khula"
   homepage "https://fonts.google.com/specimen/Khula"
 

--- a/Casks/font-kiwi-maru.rb
+++ b/Casks/font-kiwi-maru.rb
@@ -2,9 +2,10 @@ cask "font-kiwi-maru" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kiwimaru",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kiwimaru"
   name "Kiwi Maru"
   desc "Typeface for visualization of everyday and slang expressions"
   homepage "https://fonts.google.com/specimen/Kiwi+Maru"

--- a/Casks/font-klee-one.rb
+++ b/Casks/font-klee-one.rb
@@ -2,9 +2,10 @@ cask "font-klee-one" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kleeone",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kleeone"
   name "Klee One"
   homepage "https://fonts.google.com/specimen/Klee+One"
 

--- a/Casks/font-ko-pub-batang.rb
+++ b/Casks/font-ko-pub-batang.rb
@@ -2,9 +2,10 @@ cask "font-ko-pub-batang" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kopubbatang",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kopubbatang"
   name "Ko Pub Batang"
   homepage "https://fonts.google.com/earlyaccess"
 

--- a/Casks/font-kodchasan.rb
+++ b/Casks/font-kodchasan.rb
@@ -2,9 +2,10 @@ cask "font-kodchasan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kodchasan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kodchasan"
   name "Kodchasan"
   homepage "https://fonts.google.com/specimen/Kodchasan"
 

--- a/Casks/font-koh-santepheap.rb
+++ b/Casks/font-koh-santepheap.rb
@@ -2,9 +2,10 @@ cask "font-koh-santepheap" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kohsantepheap",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kohsantepheap"
   name "Koh Santepheap"
   desc "Khmer font for body text"
   homepage "https://fonts.google.com/specimen/Koh+Santepheap"

--- a/Casks/font-koho.rb
+++ b/Casks/font-koho.rb
@@ -2,9 +2,10 @@ cask "font-koho" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/koho",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/koho"
   name "KoHo"
   homepage "https://fonts.google.com/specimen/KoHo"
 

--- a/Casks/font-krub.rb
+++ b/Casks/font-krub.rb
@@ -2,9 +2,10 @@ cask "font-krub" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/krub",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/krub"
   name "Krub"
   homepage "https://fonts.google.com/specimen/Krub"
 

--- a/Casks/font-kufam.rb
+++ b/Casks/font-kufam.rb
@@ -2,9 +2,10 @@ cask "font-kufam" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kufam",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kufam"
   name "Kufam"
   desc "Arabic-Latin bilingual typeface intended for contemporary information design"
   homepage "https://fonts.google.com/specimen/Kufam"

--- a/Casks/font-kulim-park.rb
+++ b/Casks/font-kulim-park.rb
@@ -2,9 +2,10 @@ cask "font-kulim-park" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/kulimpark",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/kulimpark"
   name "Kulim Park"
   homepage "https://fonts.google.com/specimen/Kulim+Park"
 

--- a/Casks/font-lateef.rb
+++ b/Casks/font-lateef.rb
@@ -2,9 +2,10 @@ cask "font-lateef" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lateef",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lateef"
   name "Lateef"
   homepage "https://fonts.google.com/specimen/Lateef"
 

--- a/Casks/font-lekton.rb
+++ b/Casks/font-lekton.rb
@@ -2,9 +2,10 @@ cask "font-lekton" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lekton",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lekton"
   name "Lekton"
   homepage "https://fonts.google.com/specimen/Lekton"
 

--- a/Casks/font-libre-baskerville.rb
+++ b/Casks/font-libre-baskerville.rb
@@ -2,9 +2,10 @@ cask "font-libre-baskerville" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/librebaskerville",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/librebaskerville"
   name "Libre Baskerville"
   homepage "https://fonts.google.com/specimen/Libre+Baskerville"
 

--- a/Casks/font-libre-bodoni.rb
+++ b/Casks/font-libre-bodoni.rb
@@ -2,9 +2,10 @@ cask "font-libre-bodoni" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/librebodoni",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/librebodoni"
   name "Libre Bodoni"
   homepage "https://fonts.google.com/specimen/Libre+Bodoni"
 

--- a/Casks/font-life-savers.rb
+++ b/Casks/font-life-savers.rb
@@ -2,9 +2,10 @@ cask "font-life-savers" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lifesavers",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lifesavers"
   name "Life Savers"
   homepage "https://fonts.google.com/specimen/Life+Savers"
 

--- a/Casks/font-linden-hill.rb
+++ b/Casks/font-linden-hill.rb
@@ -2,9 +2,10 @@ cask "font-linden-hill" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lindenhill",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lindenhill"
   name "Linden Hill"
   homepage "https://fonts.google.com/specimen/Linden+Hill"
 

--- a/Casks/font-literata.rb
+++ b/Casks/font-literata.rb
@@ -2,9 +2,10 @@ cask "font-literata" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/literata",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/literata"
   name "Literata"
   homepage "https://fonts.google.com/specimen/Literata"
 

--- a/Casks/font-livvic.rb
+++ b/Casks/font-livvic.rb
@@ -2,9 +2,10 @@ cask "font-livvic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/livvic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/livvic"
   name "Livvic"
   homepage "https://fonts.google.com/specimen/Livvic"
 

--- a/Casks/font-lobster-two.rb
+++ b/Casks/font-lobster-two.rb
@@ -2,9 +2,10 @@ cask "font-lobster-two" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lobstertwo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lobstertwo"
   name "Lobster Two"
   homepage "https://fonts.google.com/specimen/Lobster+Two"
 

--- a/Casks/font-londrina-solid.rb
+++ b/Casks/font-londrina-solid.rb
@@ -2,9 +2,10 @@ cask "font-londrina-solid" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/londrinasolid",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/londrinasolid"
   name "Londrina Solid"
   homepage "https://fonts.google.com/specimen/Londrina+Solid"
 

--- a/Casks/font-lora.rb
+++ b/Casks/font-lora.rb
@@ -2,9 +2,10 @@ cask "font-lora" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lora",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lora"
   name "Lora"
   homepage "https://fonts.google.com/specimen/Lora"
 

--- a/Casks/font-lusitana.rb
+++ b/Casks/font-lusitana.rb
@@ -2,9 +2,10 @@ cask "font-lusitana" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/lusitana",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/lusitana"
   name "Lusitana"
   homepage "https://fonts.google.com/specimen/Lusitana"
 

--- a/Casks/font-m-plus-1p.rb
+++ b/Casks/font-m-plus-1p.rb
@@ -2,9 +2,10 @@ cask "font-m-plus-1p" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mplus1p",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mplus1p"
   name "M PLUS 1p"
   homepage "https://fonts.google.com/specimen/M+PLUS+1p"
 

--- a/Casks/font-mada.rb
+++ b/Casks/font-mada.rb
@@ -2,9 +2,10 @@ cask "font-mada" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mada",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mada"
   name "Mada"
   homepage "https://fonts.google.com/specimen/Mada"
 

--- a/Casks/font-magra.rb
+++ b/Casks/font-magra.rb
@@ -2,9 +2,10 @@ cask "font-magra" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/magra",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/magra"
   name "Magra"
   homepage "https://fonts.google.com/specimen/Magra"
 

--- a/Casks/font-maitree.rb
+++ b/Casks/font-maitree.rb
@@ -2,9 +2,10 @@ cask "font-maitree" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/maitree",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/maitree"
   name "Maitree"
   homepage "https://fonts.google.com/specimen/Maitree"
 

--- a/Casks/font-mali.rb
+++ b/Casks/font-mali.rb
@@ -2,9 +2,10 @@ cask "font-mali" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mali",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mali"
   name "Mali"
   homepage "https://fonts.google.com/specimen/Mali"
 

--- a/Casks/font-manjari.rb
+++ b/Casks/font-manjari.rb
@@ -2,9 +2,10 @@ cask "font-manjari" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/manjari",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/manjari"
   name "Manjari"
   homepage "https://fonts.google.com/specimen/Manjari"
 

--- a/Casks/font-manuale.rb
+++ b/Casks/font-manuale.rb
@@ -2,9 +2,10 @@ cask "font-manuale" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/manuale",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/manuale"
   name "Manuale"
   homepage "https://fonts.google.com/specimen/Manuale"
 

--- a/Casks/font-martel-sans.rb
+++ b/Casks/font-martel-sans.rb
@@ -2,9 +2,10 @@ cask "font-martel-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/martelsans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/martelsans"
   name "Martel Sans"
   homepage "https://fonts.google.com/specimen/Martel+Sans"
 

--- a/Casks/font-martel.rb
+++ b/Casks/font-martel.rb
@@ -2,9 +2,10 @@ cask "font-martel" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/martel",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/martel"
   name "Martel"
   homepage "https://fonts.google.com/specimen/Martel"
 

--- a/Casks/font-marvel.rb
+++ b/Casks/font-marvel.rb
@@ -2,9 +2,10 @@ cask "font-marvel" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/marvel",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/marvel"
   name "Marvel"
   homepage "https://fonts.google.com/specimen/Marvel"
 

--- a/Casks/font-mate.rb
+++ b/Casks/font-mate.rb
@@ -2,9 +2,10 @@ cask "font-mate" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mate",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mate"
   name "Mate"
   homepage "https://fonts.google.com/specimen/Mate"
 

--- a/Casks/font-merriweather-sans.rb
+++ b/Casks/font-merriweather-sans.rb
@@ -2,9 +2,10 @@ cask "font-merriweather-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/merriweathersans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/merriweathersans"
   name "Merriweather Sans"
   homepage "https://fonts.google.com/specimen/Merriweather+Sans"
 

--- a/Casks/font-merriweather.rb
+++ b/Casks/font-merriweather.rb
@@ -2,9 +2,10 @@ cask "font-merriweather" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/merriweather",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/merriweather"
   name "Merriweather"
   homepage "https://fonts.google.com/specimen/Merriweather"
 

--- a/Casks/font-mina.rb
+++ b/Casks/font-mina.rb
@@ -2,9 +2,10 @@ cask "font-mina" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mina",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mina"
   name "Mina"
   homepage "https://fonts.google.com/specimen/Mina"
 

--- a/Casks/font-miriam-libre.rb
+++ b/Casks/font-miriam-libre.rb
@@ -2,9 +2,10 @@ cask "font-miriam-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/miriamlibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/miriamlibre"
   name "Miriam Libre"
   homepage "https://fonts.google.com/specimen/Miriam+Libre"
 

--- a/Casks/font-mirza.rb
+++ b/Casks/font-mirza.rb
@@ -2,9 +2,10 @@ cask "font-mirza" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mirza",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mirza"
   name "Mirza"
   homepage "https://fonts.google.com/specimen/Mirza"
 

--- a/Casks/font-mitr.rb
+++ b/Casks/font-mitr.rb
@@ -2,9 +2,10 @@ cask "font-mitr" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mitr",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mitr"
   name "Mitr"
   homepage "https://fonts.google.com/specimen/Mitr"
 

--- a/Casks/font-mohave.rb
+++ b/Casks/font-mohave.rb
@@ -2,9 +2,10 @@ cask "font-mohave" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mohave",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mohave"
   name "Mohave"
   homepage "https://fonts.google.com/specimen/Mohave"
 

--- a/Casks/font-monda.rb
+++ b/Casks/font-monda.rb
@@ -2,9 +2,10 @@ cask "font-monda" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/monda",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/monda"
   name "Monda"
   homepage "https://fonts.google.com/specimen/Monda"
 

--- a/Casks/font-montserrat-alternates.rb
+++ b/Casks/font-montserrat-alternates.rb
@@ -2,9 +2,10 @@ cask "font-montserrat-alternates" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/montserratalternates",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/montserratalternates"
   name "Montserrat Alternates"
   homepage "https://fonts.google.com/specimen/Montserrat+Alternates"
 

--- a/Casks/font-montserrat-subrayada.rb
+++ b/Casks/font-montserrat-subrayada.rb
@@ -2,9 +2,10 @@ cask "font-montserrat-subrayada" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/montserratsubrayada",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/montserratsubrayada"
   name "Montserrat Subrayada"
   homepage "https://fonts.google.com/specimen/Montserrat+Subrayada"
 

--- a/Casks/font-montserrat.rb
+++ b/Casks/font-montserrat.rb
@@ -2,9 +2,10 @@ cask "font-montserrat" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/montserrat",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/montserrat"
   name "Montserrat"
   homepage "https://fonts.google.com/specimen/Montserrat"
 

--- a/Casks/font-mountains-of-christmas.rb
+++ b/Casks/font-mountains-of-christmas.rb
@@ -2,9 +2,10 @@ cask "font-mountains-of-christmas" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/mountainsofchristmas",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/mountainsofchristmas"
   name "Mountains of Christmas"
   homepage "https://fonts.google.com/specimen/Mountains+of+Christmas"
 

--- a/Casks/font-mukta-mahee.rb
+++ b/Casks/font-mukta-mahee.rb
@@ -2,9 +2,10 @@ cask "font-mukta-mahee" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/muktamahee",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/muktamahee"
   name "Mukta Mahee"
   homepage "https://fonts.google.com/specimen/Mukta+Mahee"
 

--- a/Casks/font-mukta-malar.rb
+++ b/Casks/font-mukta-malar.rb
@@ -2,9 +2,10 @@ cask "font-mukta-malar" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/muktamalar",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/muktamalar"
   name "Mukta Malar"
   homepage "https://fonts.google.com/specimen/Mukta+Malar"
 

--- a/Casks/font-mukta-vaani.rb
+++ b/Casks/font-mukta-vaani.rb
@@ -2,9 +2,10 @@ cask "font-mukta-vaani" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/muktavaani",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/muktavaani"
   name "Mukta Vaani"
   homepage "https://fonts.google.com/specimen/Mukta+Vaani"
 

--- a/Casks/font-mukta.rb
+++ b/Casks/font-mukta.rb
@@ -2,9 +2,10 @@ cask "font-mukta" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mukta",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mukta"
   name "Mukta"
   homepage "https://fonts.google.com/specimen/Mukta"
 

--- a/Casks/font-mulish.rb
+++ b/Casks/font-mulish.rb
@@ -2,9 +2,10 @@ cask "font-mulish" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/mulish",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/mulish"
   name "Mulish"
   desc "Minimalist sans serif typeface, designed for both display and text typography"
   homepage "https://fonts.google.com/specimen/Mulish"

--- a/Casks/font-museomoderno.rb
+++ b/Casks/font-museomoderno.rb
@@ -2,9 +2,10 @@ cask "font-museomoderno" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/museomoderno",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/museomoderno"
   name "MuseoModerno"
   homepage "https://fonts.google.com/specimen/MuseoModerno"
 

--- a/Casks/font-nanum-gothic-coding.rb
+++ b/Casks/font-nanum-gothic-coding.rb
@@ -2,9 +2,10 @@ cask "font-nanum-gothic-coding" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nanumgothiccoding",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nanumgothiccoding"
   name "Nanum Gothic Coding"
   homepage "https://fonts.google.com/specimen/Nanum+Gothic+Coding"
 

--- a/Casks/font-nanum-gothic.rb
+++ b/Casks/font-nanum-gothic.rb
@@ -2,9 +2,10 @@ cask "font-nanum-gothic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nanumgothic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nanumgothic"
   name "Nanum Gothic"
   homepage "https://fonts.google.com/specimen/Nanum+Gothic"
 

--- a/Casks/font-nanum-myeongjo.rb
+++ b/Casks/font-nanum-myeongjo.rb
@@ -2,9 +2,10 @@ cask "font-nanum-myeongjo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nanummyeongjo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nanummyeongjo"
   name "Nanum Myeongjo"
   homepage "https://fonts.google.com/specimen/Nanum+Myeongjo"
 

--- a/Casks/font-neuton.rb
+++ b/Casks/font-neuton.rb
@@ -2,9 +2,10 @@ cask "font-neuton" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/neuton",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/neuton"
   name "Neuton"
   homepage "https://fonts.google.com/specimen/Neuton"
 

--- a/Casks/font-news-cycle.rb
+++ b/Casks/font-news-cycle.rb
@@ -2,9 +2,10 @@ cask "font-news-cycle" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/newscycle",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/newscycle"
   name "News Cycle"
   homepage "https://fonts.google.com/specimen/News+Cycle"
 

--- a/Casks/font-newsreader.rb
+++ b/Casks/font-newsreader.rb
@@ -2,9 +2,10 @@ cask "font-newsreader" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/newsreader",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/newsreader"
   name "Newsreader"
   desc "Original typeface primarily intended for continuous on-screen reading"
   homepage "https://fonts.google.com/specimen/Newsreader"

--- a/Casks/font-niramit.rb
+++ b/Casks/font-niramit.rb
@@ -2,9 +2,10 @@ cask "font-niramit" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/niramit",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/niramit"
   name "Niramit"
   homepage "https://fonts.google.com/specimen/Niramit"
 

--- a/Casks/font-nobile.rb
+++ b/Casks/font-nobile.rb
@@ -2,9 +2,10 @@ cask "font-nobile" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nobile",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nobile"
   name "Nobile"
   homepage "https://fonts.google.com/specimen/Nobile"
 

--- a/Casks/font-nokora.rb
+++ b/Casks/font-nokora.rb
@@ -2,9 +2,10 @@ cask "font-nokora" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nokora",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nokora"
   name "Nokora"
   homepage "https://fonts.google.com/specimen/Nokora"
 

--- a/Casks/font-noticia-text.rb
+++ b/Casks/font-noticia-text.rb
@@ -2,9 +2,10 @@ cask "font-noticia-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/noticiatext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/noticiatext"
   name "Noticia Text"
   homepage "https://fonts.google.com/specimen/Noticia+Text"
 

--- a/Casks/font-noto-sans-devanagari-ui.rb
+++ b/Casks/font-noto-sans-devanagari-ui.rb
@@ -2,9 +2,10 @@ cask "font-noto-sans-devanagari-ui" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/notosansdevanagariui",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosansdevanagariui"
   name "Noto Sans Devanagari UI"
   homepage "https://fonts.google.com/specimen/Noto+Sans+Devanagari+UI"
 

--- a/Casks/font-noto-sans-gujarati-ui.rb
+++ b/Casks/font-noto-sans-gujarati-ui.rb
@@ -2,9 +2,10 @@ cask "font-noto-sans-gujarati-ui" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/notosansgujaratiui",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosansgujaratiui"
   name "Noto Sans Gujarati UI"
   homepage "https://fonts.google.com/specimen/Noto+Sans+Gujarati+UI"
 

--- a/Casks/font-noto-sans-myanmar-ui.rb
+++ b/Casks/font-noto-sans-myanmar-ui.rb
@@ -2,9 +2,10 @@ cask "font-noto-sans-myanmar-ui" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/notosansmyanmarui",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosansmyanmarui"
   name "Noto Sans Myanmar UI"
   homepage "https://fonts.google.com/specimen/Noto+Sans+Myanmar+UI"
 

--- a/Casks/font-noto-sans-oriya-ui.rb
+++ b/Casks/font-noto-sans-oriya-ui.rb
@@ -2,9 +2,10 @@ cask "font-noto-sans-oriya-ui" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/notosansoriyaui",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosansoriyaui"
   name "Noto Sans Oriya UI"
   homepage "https://fonts.google.com/specimen/Noto+Sans+Oriya+UI"
 

--- a/Casks/font-noto-sans-syriac.rb
+++ b/Casks/font-noto-sans-syriac.rb
@@ -2,9 +2,10 @@ cask "font-noto-sans-syriac" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/notosanssyriac",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosanssyriac"
   name "Noto Sans Syriac"
   homepage "https://fonts.google.com/specimen/Noto+Sans+Syriac"
 

--- a/Casks/font-noto-sans-thai-looped.rb
+++ b/Casks/font-noto-sans-thai-looped.rb
@@ -2,9 +2,10 @@ cask "font-noto-sans-thai-looped" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/notosansthailooped",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosansthailooped"
   name "Noto Sans Thai Looped"
   homepage "https://fonts.google.com/specimen/Noto+Sans+Thai+Looped"
 

--- a/Casks/font-nunito-sans.rb
+++ b/Casks/font-nunito-sans.rb
@@ -2,9 +2,10 @@ cask "font-nunito-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nunitosans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nunitosans"
   name "Nunito Sans"
   homepage "https://fonts.google.com/specimen/Nunito+Sans"
 

--- a/Casks/font-nunito.rb
+++ b/Casks/font-nunito.rb
@@ -2,9 +2,10 @@ cask "font-nunito" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/nunito",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/nunito"
   name "Nunito"
   homepage "https://fonts.google.com/specimen/Nunito"
 

--- a/Casks/font-ofl-sorts-mill-goudy-tt.rb
+++ b/Casks/font-ofl-sorts-mill-goudy-tt.rb
@@ -2,9 +2,10 @@ cask "font-ofl-sorts-mill-goudy-tt" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/oflsortsmillgoudytt",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/oflsortsmillgoudytt"
   name "OFL Sorts Mill Goudy TT"
   homepage "https://fonts.google.com/specimen/OFL+Sorts+Mill+Goudy+TT"
 

--- a/Casks/font-old-standard-tt.rb
+++ b/Casks/font-old-standard-tt.rb
@@ -2,9 +2,10 @@ cask "font-old-standard-tt" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/oldstandardtt",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/oldstandardtt"
   name "Old Standard TT"
   homepage "https://fonts.google.com/specimen/Old+Standard+TT"
 

--- a/Casks/font-oleo-script-swash-caps.rb
+++ b/Casks/font-oleo-script-swash-caps.rb
@@ -2,9 +2,10 @@ cask "font-oleo-script-swash-caps" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/oleoscriptswashcaps",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/oleoscriptswashcaps"
   name "Oleo Script Swash Caps"
   homepage "https://fonts.google.com/specimen/Oleo+Script+Swash+Caps"
 

--- a/Casks/font-oleo-script.rb
+++ b/Casks/font-oleo-script.rb
@@ -2,9 +2,10 @@ cask "font-oleo-script" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/oleoscript",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/oleoscript"
   name "Oleo Script"
   homepage "https://fonts.google.com/specimen/Oleo+Script"
 

--- a/Casks/font-open-sans-condensed.rb
+++ b/Casks/font-open-sans-condensed.rb
@@ -2,9 +2,10 @@ cask "font-open-sans-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/opensanscondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/opensanscondensed"
   name "Open Sans Condensed"
   homepage "https://fonts.google.com/specimen/Open+Sans+Condensed"
 

--- a/Casks/font-open-sans-hebrew-condensed.rb
+++ b/Casks/font-open-sans-hebrew-condensed.rb
@@ -2,9 +2,10 @@ cask "font-open-sans-hebrew-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/opensanshebrewcondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/opensanshebrewcondensed"
   name "Open Sans Hebrew Condensed"
   homepage "https://fonts.google.com/earlyaccess"
 

--- a/Casks/font-open-sans-hebrew.rb
+++ b/Casks/font-open-sans-hebrew.rb
@@ -2,9 +2,10 @@ cask "font-open-sans-hebrew" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/opensanshebrew",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/opensanshebrew"
   name "Open Sans Hebrew"
   homepage "https://fonts.google.com/earlyaccess"
 

--- a/Casks/font-open-sans.rb
+++ b/Casks/font-open-sans.rb
@@ -2,9 +2,10 @@ cask "font-open-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/opensans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/opensans"
   name "Open Sans"
   homepage "https://fonts.google.com/specimen/Open+Sans"
 

--- a/Casks/font-oregano.rb
+++ b/Casks/font-oregano.rb
@@ -2,9 +2,10 @@ cask "font-oregano" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/oregano",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/oregano"
   name "Oregano"
   homepage "https://fonts.google.com/specimen/Oregano"
 

--- a/Casks/font-overlock.rb
+++ b/Casks/font-overlock.rb
@@ -2,9 +2,10 @@ cask "font-overlock" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/overlock",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/overlock"
   name "Overlock"
   homepage "https://fonts.google.com/specimen/Overlock"
 

--- a/Casks/font-oxygen.rb
+++ b/Casks/font-oxygen.rb
@@ -2,9 +2,10 @@ cask "font-oxygen" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/oxygen",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/oxygen"
   name "Oxygen"
   homepage "https://fonts.google.com/specimen/Oxygen"
 

--- a/Casks/font-padauk.rb
+++ b/Casks/font-padauk.rb
@@ -2,9 +2,10 @@ cask "font-padauk" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/padauk",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/padauk"
   name "Padauk"
   homepage "https://fonts.google.com/specimen/Padauk"
 

--- a/Casks/font-palanquin-dark.rb
+++ b/Casks/font-palanquin-dark.rb
@@ -2,9 +2,10 @@ cask "font-palanquin-dark" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/palanquindark",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/palanquindark"
   name "Palanquin Dark"
   homepage "https://fonts.google.com/specimen/Palanquin+Dark"
 

--- a/Casks/font-palanquin.rb
+++ b/Casks/font-palanquin.rb
@@ -2,9 +2,10 @@ cask "font-palanquin" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/palanquin",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/palanquin"
   name "Palanquin"
   homepage "https://fonts.google.com/specimen/Palanquin"
 

--- a/Casks/font-passion-one.rb
+++ b/Casks/font-passion-one.rb
@@ -2,9 +2,10 @@ cask "font-passion-one" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/passionone",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/passionone"
   name "Passion One"
   homepage "https://fonts.google.com/specimen/Passion+One"
 

--- a/Casks/font-petrona.rb
+++ b/Casks/font-petrona.rb
@@ -2,9 +2,10 @@ cask "font-petrona" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/petrona",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/petrona"
   name "Petrona"
   homepage "https://fonts.google.com/specimen/Petrona"
 

--- a/Casks/font-phetsarath.rb
+++ b/Casks/font-phetsarath.rb
@@ -2,9 +2,10 @@ cask "font-phetsarath" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/phetsarath",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/phetsarath"
   name "Phetsarath"
   homepage "https://fonts.google.com/specimen/Phetsarath"
 

--- a/Casks/font-philosopher.rb
+++ b/Casks/font-philosopher.rb
@@ -2,9 +2,10 @@ cask "font-philosopher" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/philosopher",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/philosopher"
   name "Philosopher"
   homepage "https://fonts.google.com/specimen/Philosopher"
 

--- a/Casks/font-piazzolla.rb
+++ b/Casks/font-piazzolla.rb
@@ -2,9 +2,10 @@ cask "font-piazzolla" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/piazzolla",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/piazzolla"
   name "Piazzolla"
   desc "Serif font family for media"
   homepage "https://fonts.google.com/specimen/Piazzolla"

--- a/Casks/font-play.rb
+++ b/Casks/font-play.rb
@@ -2,9 +2,10 @@ cask "font-play" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/play",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/play"
   name "Play"
   homepage "https://fonts.google.com/specimen/Play"
 

--- a/Casks/font-playfair-display-sc.rb
+++ b/Casks/font-playfair-display-sc.rb
@@ -2,9 +2,10 @@ cask "font-playfair-display-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/playfairdisplaysc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/playfairdisplaysc"
   name "Playfair Display SC"
   homepage "https://fonts.google.com/specimen/Playfair+Display+SC"
 

--- a/Casks/font-playfair-display.rb
+++ b/Casks/font-playfair-display.rb
@@ -2,9 +2,10 @@ cask "font-playfair-display" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/playfairdisplay",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/playfairdisplay"
   name "Playfair Display"
   homepage "https://fonts.google.com/specimen/Playfair+Display"
 

--- a/Casks/font-plus-jakarta-sans.rb
+++ b/Casks/font-plus-jakarta-sans.rb
@@ -2,9 +2,10 @@ cask "font-plus-jakarta-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/plusjakartasans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/plusjakartasans"
   name "Plus Jakarta Sans"
   desc "Versatile modern type family"
   homepage "https://fonts.google.com/specimen/Plus+Jakarta+Sans"

--- a/Casks/font-poly.rb
+++ b/Casks/font-poly.rb
@@ -2,9 +2,10 @@ cask "font-poly" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/poly",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/poly"
   name "Poly"
   homepage "https://fonts.google.com/specimen/Poly"
 

--- a/Casks/font-post-no-bills-colombo.rb
+++ b/Casks/font-post-no-bills-colombo.rb
@@ -2,9 +2,10 @@ cask "font-post-no-bills-colombo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/postnobillscolombo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/postnobillscolombo"
   name "Post No Bills Colombo"
   homepage "https://fonts.google.com/specimen/Post+No+Bills+Colombo"
 

--- a/Casks/font-post-no-bills-jaffna.rb
+++ b/Casks/font-post-no-bills-jaffna.rb
@@ -2,9 +2,10 @@ cask "font-post-no-bills-jaffna" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/postnobillsjaffna",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/postnobillsjaffna"
   name "Post No Bills Jaffna"
   homepage "https://fonts.google.com/specimen/Post+No+Bills+Jaffna"
 

--- a/Casks/font-pragati-narrow.rb
+++ b/Casks/font-pragati-narrow.rb
@@ -2,9 +2,10 @@ cask "font-pragati-narrow" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/pragatinarrow",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/pragatinarrow"
   name "Pragati Narrow"
   homepage "https://fonts.google.com/specimen/Pragati+Narrow"
 

--- a/Casks/font-pridi.rb
+++ b/Casks/font-pridi.rb
@@ -2,9 +2,10 @@ cask "font-pridi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/pridi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/pridi"
   name "Pridi"
   homepage "https://fonts.google.com/specimen/Pridi"
 

--- a/Casks/font-prompt.rb
+++ b/Casks/font-prompt.rb
@@ -2,9 +2,10 @@ cask "font-prompt" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/prompt",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/prompt"
   name "Prompt"
   homepage "https://fonts.google.com/specimen/Prompt"
 

--- a/Casks/font-pt-sans-caption.rb
+++ b/Casks/font-pt-sans-caption.rb
@@ -2,9 +2,10 @@ cask "font-pt-sans-caption" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ptsanscaption",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ptsanscaption"
   name "PT Sans Caption"
   homepage "https://fonts.google.com/specimen/PT+Sans+Caption"
 

--- a/Casks/font-pt-sans-narrow.rb
+++ b/Casks/font-pt-sans-narrow.rb
@@ -2,9 +2,10 @@ cask "font-pt-sans-narrow" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ptsansnarrow",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ptsansnarrow"
   name "PT Sans Narrow"
   homepage "https://fonts.google.com/specimen/PT+Sans+Narrow"
 

--- a/Casks/font-pt-serif-caption.rb
+++ b/Casks/font-pt-serif-caption.rb
@@ -2,9 +2,10 @@ cask "font-pt-serif-caption" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ptserifcaption",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ptserifcaption"
   name "PT Serif Caption"
   homepage "https://fonts.google.com/specimen/PT+Serif+Caption"
 

--- a/Casks/font-puritan.rb
+++ b/Casks/font-puritan.rb
@@ -2,9 +2,10 @@ cask "font-puritan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/puritan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/puritan"
   name "Puritan"
   homepage "https://fonts.google.com/specimen/Puritan"
 

--- a/Casks/font-quantico.rb
+++ b/Casks/font-quantico.rb
@@ -2,9 +2,10 @@ cask "font-quantico" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/quantico",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/quantico"
   name "Quantico"
   homepage "https://fonts.google.com/specimen/Quantico"
 

--- a/Casks/font-quattrocento-sans.rb
+++ b/Casks/font-quattrocento-sans.rb
@@ -2,9 +2,10 @@ cask "font-quattrocento-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/quattrocentosans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/quattrocentosans"
   name "Quattrocento Sans"
   homepage "https://fonts.google.com/specimen/Quattrocento+Sans"
 

--- a/Casks/font-quattrocento.rb
+++ b/Casks/font-quattrocento.rb
@@ -2,9 +2,10 @@ cask "font-quattrocento" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/quattrocento",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/quattrocento"
   name "Quattrocento"
   homepage "https://fonts.google.com/specimen/Quattrocento"
 

--- a/Casks/font-qwitcher-grypen.rb
+++ b/Casks/font-qwitcher-grypen.rb
@@ -2,9 +2,10 @@ cask "font-qwitcher-grypen" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/qwitchergrypen",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/qwitchergrypen"
   name "Qwitcher Grypen"
   desc "Casual brush script with a bit of an edge"
   homepage "https://fonts.google.com/specimen/Qwitcher+Grypen"

--- a/Casks/font-radio-canada.rb
+++ b/Casks/font-radio-canada.rb
@@ -2,9 +2,10 @@ cask "font-radio-canada" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/radiocanada",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/radiocanada"
   name "Radio Canada"
   homepage "https://fonts.google.com/specimen/Radio+Canada"
 

--- a/Casks/font-radley.rb
+++ b/Casks/font-radley.rb
@@ -2,9 +2,10 @@ cask "font-radley" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/radley",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/radley"
   name "Radley"
   homepage "https://fonts.google.com/specimen/Radley"
 

--- a/Casks/font-rambla.rb
+++ b/Casks/font-rambla.rb
@@ -2,9 +2,10 @@ cask "font-rambla" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rambla",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rambla"
   name "Rambla"
   homepage "https://fonts.google.com/specimen/Rambla"
 

--- a/Casks/font-ranga.rb
+++ b/Casks/font-ranga.rb
@@ -2,9 +2,10 @@ cask "font-ranga" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ranga",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ranga"
   name "Ranga"
   homepage "https://fonts.google.com/specimen/Ranga"
 

--- a/Casks/font-rasa.rb
+++ b/Casks/font-rasa.rb
@@ -2,9 +2,10 @@ cask "font-rasa" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rasa",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rasa"
   name "Rasa"
   homepage "https://fonts.google.com/specimen/Rasa"
 

--- a/Casks/font-red-hat-display.rb
+++ b/Casks/font-red-hat-display.rb
@@ -2,9 +2,10 @@ cask "font-red-hat-display" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/redhatdisplay",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/redhatdisplay"
   name "Red Hat Display"
   homepage "https://fonts.google.com/specimen/Red+Hat+Display"
 

--- a/Casks/font-red-hat-mono.rb
+++ b/Casks/font-red-hat-mono.rb
@@ -2,9 +2,10 @@ cask "font-red-hat-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/redhatmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/redhatmono"
   name "Red Hat Mono"
   homepage "https://fonts.google.com/specimen/Red+Hat+Mono"
 

--- a/Casks/font-red-hat-text.rb
+++ b/Casks/font-red-hat-text.rb
@@ -2,9 +2,10 @@ cask "font-red-hat-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/redhattext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/redhattext"
   name "Red Hat Text"
   homepage "https://fonts.google.com/specimen/Red+Hat+Text"
 

--- a/Casks/font-redacted-script.rb
+++ b/Casks/font-redacted-script.rb
@@ -2,9 +2,10 @@ cask "font-redacted-script" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/redactedscript",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/redactedscript"
   name "Redacted Script"
   homepage "https://fonts.google.com/specimen/Redacted+Script"
 

--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -2,9 +2,10 @@ cask "font-roboto-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/robotomono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/robotomono"
   name "Roboto Mono"
   homepage "https://fonts.google.com/specimen/Roboto+Mono"
 

--- a/Casks/font-roboto-serif.rb
+++ b/Casks/font-roboto-serif.rb
@@ -2,9 +2,10 @@ cask "font-roboto-serif" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/robotoserif",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/robotoserif"
   name "Roboto Serif"
   desc "Just as comfortable to read and work in print media"
   homepage "https://fonts.google.com/specimen/Roboto+Serif"

--- a/Casks/font-roboto.rb
+++ b/Casks/font-roboto.rb
@@ -2,9 +2,10 @@ cask "font-roboto" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/roboto",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/roboto"
   name "Roboto"
   desc "Font with a mechanical skeleton and the forms are largely geometric"
   homepage "https://fonts.google.com/specimen/Roboto"

--- a/Casks/font-ropa-sans.rb
+++ b/Casks/font-ropa-sans.rb
@@ -2,9 +2,10 @@ cask "font-ropa-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/ropasans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/ropasans"
   name "Ropa Sans"
   homepage "https://fonts.google.com/specimen/Ropa+Sans"
 

--- a/Casks/font-rosario.rb
+++ b/Casks/font-rosario.rb
@@ -2,9 +2,10 @@ cask "font-rosario" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rosario",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rosario"
   name "Rosario"
   homepage "https://fonts.google.com/specimen/Rosario"
 

--- a/Casks/font-rosarivo.rb
+++ b/Casks/font-rosarivo.rb
@@ -2,9 +2,10 @@ cask "font-rosarivo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rosarivo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rosarivo"
   name "Rosarivo"
   homepage "https://fonts.google.com/specimen/Rosarivo"
 

--- a/Casks/font-rowdies.rb
+++ b/Casks/font-rowdies.rb
@@ -2,9 +2,10 @@ cask "font-rowdies" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rowdies",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rowdies"
   name "Rowdies"
   homepage "https://fonts.google.com/specimen/Rowdies"
 

--- a/Casks/font-rubik.rb
+++ b/Casks/font-rubik.rb
@@ -2,9 +2,10 @@ cask "font-rubik" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rubik",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rubik"
   name "Rubik"
   homepage "https://fonts.google.com/specimen/Rubik"
 

--- a/Casks/font-rufina.rb
+++ b/Casks/font-rufina.rb
@@ -2,9 +2,10 @@ cask "font-rufina" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/rufina",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/rufina"
   name "Rufina"
   homepage "https://fonts.google.com/specimen/Rufina"
 

--- a/Casks/font-sahitya.rb
+++ b/Casks/font-sahitya.rb
@@ -2,9 +2,10 @@ cask "font-sahitya" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sahitya",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sahitya"
   name "Sahitya"
   homepage "https://fonts.google.com/specimen/Sahitya"
 

--- a/Casks/font-saira-condensed.rb
+++ b/Casks/font-saira-condensed.rb
@@ -2,9 +2,10 @@ cask "font-saira-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sairacondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sairacondensed"
   name "Saira Condensed"
   homepage "https://fonts.google.com/specimen/Saira+Condensed"
 

--- a/Casks/font-saira-extra-condensed.rb
+++ b/Casks/font-saira-extra-condensed.rb
@@ -2,9 +2,10 @@ cask "font-saira-extra-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sairaextracondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sairaextracondensed"
   name "Saira Extra Condensed"
   homepage "https://fonts.google.com/specimen/Saira+Extra+Condensed"
 

--- a/Casks/font-saira-semi-condensed.rb
+++ b/Casks/font-saira-semi-condensed.rb
@@ -2,9 +2,10 @@ cask "font-saira-semi-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sairasemicondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sairasemicondensed"
   name "Saira Semi Condensed"
   homepage "https://fonts.google.com/specimen/Saira+Semi+Condensed"
 

--- a/Casks/font-saira.rb
+++ b/Casks/font-saira.rb
@@ -2,9 +2,10 @@ cask "font-saira" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/saira",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/saira"
   name "Saira"
   homepage "https://fonts.google.com/specimen/Saira"
 

--- a/Casks/font-sanchez.rb
+++ b/Casks/font-sanchez.rb
@@ -2,9 +2,10 @@ cask "font-sanchez" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sanchez",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sanchez"
   name "Sanchez"
   homepage "https://fonts.google.com/specimen/Sanchez"
 

--- a/Casks/font-sansation.rb
+++ b/Casks/font-sansation.rb
@@ -2,9 +2,10 @@ cask "font-sansation" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sansation",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sansation"
   name "Sansation"
   homepage "https://fonts.google.com/specimen/Sansation"
 

--- a/Casks/font-sansita.rb
+++ b/Casks/font-sansita.rb
@@ -2,9 +2,10 @@ cask "font-sansita" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sansita",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sansita"
   name "Sansita"
   homepage "https://fonts.google.com/specimen/Sansita"
 

--- a/Casks/font-sarabun.rb
+++ b/Casks/font-sarabun.rb
@@ -2,9 +2,10 @@ cask "font-sarabun" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sarabun",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sarabun"
   name "Sarabun"
   homepage "https://fonts.google.com/specimen/Sarabun"
 

--- a/Casks/font-sarala.rb
+++ b/Casks/font-sarala.rb
@@ -2,9 +2,10 @@ cask "font-sarala" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sarala",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sarala"
   name "Sarala"
   homepage "https://fonts.google.com/specimen/Sarala"
 

--- a/Casks/font-sarpanch.rb
+++ b/Casks/font-sarpanch.rb
@@ -2,9 +2,10 @@ cask "font-sarpanch" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sarpanch",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sarpanch"
   name "Sarpanch"
   homepage "https://fonts.google.com/specimen/Sarpanch"
 

--- a/Casks/font-scada.rb
+++ b/Casks/font-scada.rb
@@ -2,9 +2,10 @@ cask "font-scada" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/scada",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/scada"
   name "Scada"
   homepage "https://fonts.google.com/specimen/Scada"
 

--- a/Casks/font-scheherazade-new.rb
+++ b/Casks/font-scheherazade-new.rb
@@ -2,9 +2,10 @@ cask "font-scheherazade-new" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/scheherazadenew",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/scheherazadenew"
   name "Scheherazade New"
   desc "Named after the heroine of the classic arabian nights tale"
   homepage "https://fonts.google.com/specimen/Scheherazade+New"

--- a/Casks/font-sedan.rb
+++ b/Casks/font-sedan.rb
@@ -2,9 +2,10 @@ cask "font-sedan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sedan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sedan"
   name "Sedan"
   homepage "https://fonts.google.com/specimen/Sedan"
 

--- a/Casks/font-sen.rb
+++ b/Casks/font-sen.rb
@@ -2,9 +2,10 @@ cask "font-sen" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sen",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sen"
   name "Sen"
   homepage "https://fonts.google.com/specimen/Sen"
 

--- a/Casks/font-seoul-hangang-condensed.rb
+++ b/Casks/font-seoul-hangang-condensed.rb
@@ -2,9 +2,10 @@ cask "font-seoul-hangang-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/seoulhangangcondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/seoulhangangcondensed"
   name "Seoul Hangang Condensed"
   homepage "https://fonts.google.com/specimen/Seoul+Hangang+Condensed"
 

--- a/Casks/font-seoul-hangang.rb
+++ b/Casks/font-seoul-hangang.rb
@@ -2,9 +2,10 @@ cask "font-seoul-hangang" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/seoulhangang",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/seoulhangang"
   name "Seoul Hangang"
   homepage "https://fonts.google.com/specimen/Seoul+Hangang"
 

--- a/Casks/font-seoul-namsan-condensed.rb
+++ b/Casks/font-seoul-namsan-condensed.rb
@@ -2,9 +2,10 @@ cask "font-seoul-namsan-condensed" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/seoulnamsancondensed",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/seoulnamsancondensed"
   name "Seoul Namsan Condensed"
   homepage "https://fonts.google.com/specimen/Seoul+Namsan+Condensed"
 

--- a/Casks/font-seoul-namsan.rb
+++ b/Casks/font-seoul-namsan.rb
@@ -2,9 +2,10 @@ cask "font-seoul-namsan" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/seoulnamsan",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/seoulnamsan"
   name "Seoul Namsan"
   homepage "https://fonts.google.com/specimen/Seoul+Namsan"
 

--- a/Casks/font-share.rb
+++ b/Casks/font-share.rb
@@ -2,9 +2,10 @@ cask "font-share" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/share",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/share"
   name "Share"
   homepage "https://fonts.google.com/specimen/Share"
 

--- a/Casks/font-shippori-mincho-b1.rb
+++ b/Casks/font-shippori-mincho-b1.rb
@@ -2,9 +2,10 @@ cask "font-shippori-mincho-b1" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/shipporiminchob1",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/shipporiminchob1"
   name "Shippori Mincho B1"
   desc "Based on the Tsukiji Typeface making facility of Tokyo"
   homepage "https://fonts.google.com/specimen/Shippori+Mincho+B1"

--- a/Casks/font-shippori-mincho.rb
+++ b/Casks/font-shippori-mincho.rb
@@ -2,9 +2,10 @@ cask "font-shippori-mincho" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/shipporimincho",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/shipporimincho"
   name "Shippori Mincho"
   desc "Based on the Tsukiji Typeface making facility of Tokyo"
   homepage "https://fonts.google.com/specimen/Shippori+Mincho"

--- a/Casks/font-signika-negative-sc.rb
+++ b/Casks/font-signika-negative-sc.rb
@@ -2,9 +2,10 @@ cask "font-signika-negative-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/signikanegativesc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/signikanegativesc"
   name "Signika Negative SC"
   desc "Alternative version of the Signika SC font"
   homepage "https://fonts.google.com/specimen/Signika+Negative+SC"

--- a/Casks/font-silkscreen.rb
+++ b/Casks/font-silkscreen.rb
@@ -2,9 +2,10 @@ cask "font-silkscreen" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/silkscreen",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/silkscreen"
   name "Silkscreen"
   desc "Typeface for your web graphics"
   homepage "https://fonts.google.com/specimen/Silkscreen"

--- a/Casks/font-simonetta.rb
+++ b/Casks/font-simonetta.rb
@@ -2,9 +2,10 @@ cask "font-simonetta" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/simonetta",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/simonetta"
   name "Simonetta"
   homepage "https://fonts.google.com/specimen/Simonetta"
 

--- a/Casks/font-sintony.rb
+++ b/Casks/font-sintony.rb
@@ -2,9 +2,10 @@ cask "font-sintony" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sintony",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sintony"
   name "Sintony"
   homepage "https://fonts.google.com/specimen/Sintony"
 

--- a/Casks/font-sitara.rb
+++ b/Casks/font-sitara.rb
@@ -2,9 +2,10 @@ cask "font-sitara" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sitara",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sitara"
   name "Sitara"
   homepage "https://fonts.google.com/specimen/Sitara"
 

--- a/Casks/font-skranji.rb
+++ b/Casks/font-skranji.rb
@@ -2,9 +2,10 @@ cask "font-skranji" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/skranji",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/skranji"
   name "Skranji"
   homepage "https://fonts.google.com/specimen/Skranji"
 

--- a/Casks/font-sniglet.rb
+++ b/Casks/font-sniglet.rb
@@ -2,9 +2,10 @@ cask "font-sniglet" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sniglet",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sniglet"
   name "Sniglet"
   homepage "https://fonts.google.com/specimen/Sniglet"
 

--- a/Casks/font-sofia-sans.rb
+++ b/Casks/font-sofia-sans.rb
@@ -2,9 +2,10 @@ cask "font-sofia-sans" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sofiasans",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sofiasans"
   name "Sofia Sans"
   desc "Opentype family with large character set"
   homepage "https://fonts.google.com/specimen/Sofia+Sans"

--- a/Casks/font-solway.rb
+++ b/Casks/font-solway.rb
@@ -2,9 +2,10 @@ cask "font-solway" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/solway",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/solway"
   name "Solway"
   homepage "https://fonts.google.com/specimen/Solway"
 

--- a/Casks/font-sorts-mill-goudy.rb
+++ b/Casks/font-sorts-mill-goudy.rb
@@ -2,9 +2,10 @@ cask "font-sorts-mill-goudy" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sortsmillgoudy",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sortsmillgoudy"
   name "Sorts Mill Goudy"
   homepage "https://fonts.google.com/specimen/Sorts+Mill+Goudy"
 

--- a/Casks/font-source-code-pro.rb
+++ b/Casks/font-source-code-pro.rb
@@ -2,9 +2,10 @@ cask "font-source-code-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sourcecodepro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sourcecodepro"
   name "Source Code Pro"
   homepage "https://fonts.google.com/specimen/Source+Code+Pro"
 

--- a/Casks/font-source-sans-3.rb
+++ b/Casks/font-source-sans-3.rb
@@ -2,9 +2,10 @@ cask "font-source-sans-3" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sourcesans3",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sourcesans3"
   name "Source Sans 3"
   homepage "https://fonts.google.com/specimen/Source+Sans+3"
 

--- a/Casks/font-source-sans-pro.rb
+++ b/Casks/font-source-sans-pro.rb
@@ -2,9 +2,10 @@ cask "font-source-sans-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sourcesanspro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sourcesanspro"
   name "Source Sans Pro"
   homepage "https://fonts.google.com/specimen/Source+Sans+Pro"
 

--- a/Casks/font-source-serif-4.rb
+++ b/Casks/font-source-serif-4.rb
@@ -2,9 +2,10 @@ cask "font-source-serif-4" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sourceserif4",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sourceserif4"
   name "Source Serif 4"
   homepage "https://fonts.google.com/specimen/Source+Serif+4"
 

--- a/Casks/font-source-serif-pro.rb
+++ b/Casks/font-source-serif-pro.rb
@@ -2,9 +2,10 @@ cask "font-source-serif-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sourceserifpro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sourceserifpro"
   name "Source Serif Pro"
   homepage "https://fonts.google.com/specimen/Source+Serif+Pro"
 

--- a/Casks/font-spectral-sc.rb
+++ b/Casks/font-spectral-sc.rb
@@ -2,9 +2,10 @@ cask "font-spectral-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/spectralsc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/spectralsc"
   name "Spectral SC"
   homepage "https://fonts.google.com/specimen/Spectral+SC"
 

--- a/Casks/font-spline-sans-mono.rb
+++ b/Casks/font-spline-sans-mono.rb
@@ -2,9 +2,10 @@ cask "font-spline-sans-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/splinesansmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/splinesansmono"
   name "Spline Sans Mono"
   desc "Original typeface initiated by the spline team"
   homepage "https://fonts.google.com/specimen/Spline+Sans+Mono"

--- a/Casks/font-srisakdi.rb
+++ b/Casks/font-srisakdi.rb
@@ -2,9 +2,10 @@ cask "font-srisakdi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/srisakdi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/srisakdi"
   name "Srisakdi"
   homepage "https://fonts.google.com/specimen/Srisakdi"
 

--- a/Casks/font-stardos-stencil.rb
+++ b/Casks/font-stardos-stencil.rb
@@ -2,9 +2,10 @@ cask "font-stardos-stencil" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/stardosstencil",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/stardosstencil"
   name "Stardos Stencil"
   homepage "https://fonts.google.com/specimen/Stardos+Stencil"
 

--- a/Casks/font-stix-two-text.rb
+++ b/Casks/font-stix-two-text.rb
@@ -2,9 +2,10 @@ cask "font-stix-two-text" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/stixtwotext",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/stixtwotext"
   name "STIX Two Text"
   homepage "https://fonts.google.com/specimen/STIX+Two+Text"
 

--- a/Casks/font-stoke.rb
+++ b/Casks/font-stoke.rb
@@ -2,9 +2,10 @@ cask "font-stoke" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/stoke",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/stoke"
   name "Stoke"
   homepage "https://fonts.google.com/specimen/Stoke"
 

--- a/Casks/font-sulphur-point.rb
+++ b/Casks/font-sulphur-point.rb
@@ -2,9 +2,10 @@ cask "font-sulphur-point" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sulphurpoint",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sulphurpoint"
   name "Sulphur Point"
   homepage "https://fonts.google.com/specimen/Sulphur+Point"
 

--- a/Casks/font-sumana.rb
+++ b/Casks/font-sumana.rb
@@ -2,9 +2,10 @@ cask "font-sumana" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sumana",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sumana"
   name "Sumana"
   homepage "https://fonts.google.com/specimen/Sumana"
 

--- a/Casks/font-sunflower.rb
+++ b/Casks/font-sunflower.rb
@@ -2,9 +2,10 @@ cask "font-sunflower" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sunflower",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sunflower"
   name "Sunflower"
   homepage "https://fonts.google.com/specimen/Sunflower"
 

--- a/Casks/font-sura.rb
+++ b/Casks/font-sura.rb
@@ -2,9 +2,10 @@ cask "font-sura" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/sura",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/sura"
   name "Sura"
   homepage "https://fonts.google.com/specimen/Sura"
 

--- a/Casks/font-suwannaphum.rb
+++ b/Casks/font-suwannaphum.rb
@@ -2,9 +2,10 @@ cask "font-suwannaphum" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/suwannaphum",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/suwannaphum"
   name "Suwannaphum"
   homepage "https://fonts.google.com/specimen/Suwannaphum"
 

--- a/Casks/font-syncopate.rb
+++ b/Casks/font-syncopate.rb
@@ -2,9 +2,10 @@ cask "font-syncopate" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/syncopate",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/syncopate"
   name "Syncopate"
   homepage "https://fonts.google.com/specimen/Syncopate"
 

--- a/Casks/font-tai-heritage-pro.rb
+++ b/Casks/font-tai-heritage-pro.rb
@@ -2,9 +2,10 @@ cask "font-tai-heritage-pro" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/taiheritagepro",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/taiheritagepro"
   name "Tai Heritage Pro"
   desc "Available in regular and bold weights, with both opentype and graphite rendering"
   homepage "https://fonts.google.com/specimen/Tai+Heritage+Pro"

--- a/Casks/font-tajawal.rb
+++ b/Casks/font-tajawal.rb
@@ -2,9 +2,10 @@ cask "font-tajawal" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tajawal",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tajawal"
   name "Tajawal"
   homepage "https://fonts.google.com/specimen/Tajawal"
 

--- a/Casks/font-tangerine.rb
+++ b/Casks/font-tangerine.rb
@@ -2,9 +2,10 @@ cask "font-tangerine" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tangerine",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tangerine"
   name "Tangerine"
   homepage "https://fonts.google.com/specimen/Tangerine"
 

--- a/Casks/font-taviraj.rb
+++ b/Casks/font-taviraj.rb
@@ -2,9 +2,10 @@ cask "font-taviraj" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/taviraj",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/taviraj"
   name "Taviraj"
   homepage "https://fonts.google.com/specimen/Taviraj"
 

--- a/Casks/font-teko.rb
+++ b/Casks/font-teko.rb
@@ -2,9 +2,10 @@ cask "font-teko" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/teko",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/teko"
   name "Teko"
   homepage "https://fonts.google.com/specimen/Teko"
 

--- a/Casks/font-texturina.rb
+++ b/Casks/font-texturina.rb
@@ -2,9 +2,10 @@ cask "font-texturina" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/texturina",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/texturina"
   name "Texturina"
   desc "Designed by guillermo torres"
   homepage "https://fonts.google.com/specimen/Texturina"

--- a/Casks/font-thabit.rb
+++ b/Casks/font-thabit.rb
@@ -2,9 +2,10 @@ cask "font-thabit" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/thabit",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/thabit"
   name "Thabit"
   homepage "https://fonts.google.com/specimen/Thabit"
 

--- a/Casks/font-thasadith.rb
+++ b/Casks/font-thasadith.rb
@@ -2,9 +2,10 @@ cask "font-thasadith" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/thasadith",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/thasadith"
   name "Thasadith"
   homepage "https://fonts.google.com/specimen/Thasadith"
 

--- a/Casks/font-the-nautigal.rb
+++ b/Casks/font-the-nautigal.rb
@@ -2,9 +2,10 @@ cask "font-the-nautigal" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/thenautigal",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/thenautigal"
   name "The Nautigal"
   desc "Fluid yet formal with beautiful connectors"
   homepage "https://fonts.google.com/specimen/The+Nautigal"

--- a/Casks/font-tienne.rb
+++ b/Casks/font-tienne.rb
@@ -2,9 +2,10 @@ cask "font-tienne" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tienne",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tienne"
   name "Tienne"
   homepage "https://fonts.google.com/specimen/Tienne"
 

--- a/Casks/font-tillana.rb
+++ b/Casks/font-tillana.rb
@@ -2,9 +2,10 @@ cask "font-tillana" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tillana",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tillana"
   name "Tillana"
   homepage "https://fonts.google.com/specimen/Tillana"
 

--- a/Casks/font-tinos.rb
+++ b/Casks/font-tinos.rb
@@ -2,9 +2,10 @@ cask "font-tinos" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/tinos",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/tinos"
   name "Tinos"
   homepage "https://fonts.google.com/specimen/Tinos"
 

--- a/Casks/font-tiro-bangla.rb
+++ b/Casks/font-tiro-bangla.rb
@@ -2,9 +2,10 @@ cask "font-tiro-bangla" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirobangla",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirobangla"
   name "Tiro Bangla"
   desc "Suited to traditional literary publishing"
   homepage "https://fonts.google.com/specimen/Tiro+Bangla"

--- a/Casks/font-tiro-devanagari-hindi.rb
+++ b/Casks/font-tiro-devanagari-hindi.rb
@@ -2,9 +2,10 @@ cask "font-tiro-devanagari-hindi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirodevanagarihindi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirodevanagarihindi"
   name "Tiro Devanagari Hindi"
   desc "Broader proportions, generous counters, and strong diagonal strokes"
   homepage "https://fonts.google.com/specimen/Tiro+Devanagari+Hindi"

--- a/Casks/font-tiro-devanagari-marathi.rb
+++ b/Casks/font-tiro-devanagari-marathi.rb
@@ -2,9 +2,10 @@ cask "font-tiro-devanagari-marathi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirodevanagarimarathi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirodevanagarimarathi"
   name "Tiro Devanagari Marathi"
   desc "Broader proportions, generous counters, and strong diagonal strokes"
   homepage "https://fonts.google.com/specimen/Tiro+Devanagari+Marathi"

--- a/Casks/font-tiro-devanagari-sanskrit.rb
+++ b/Casks/font-tiro-devanagari-sanskrit.rb
@@ -2,9 +2,10 @@ cask "font-tiro-devanagari-sanskrit" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirodevanagarisanskrit",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirodevanagarisanskrit"
   name "Tiro Devanagari Sanskrit"
   desc "Broader proportions, generous counters, and strong diagonal strokes"
   homepage "https://fonts.google.com/specimen/Tiro+Devanagari+Sanskrit"

--- a/Casks/font-tiro-gurmukhi.rb
+++ b/Casks/font-tiro-gurmukhi.rb
@@ -2,9 +2,10 @@ cask "font-tiro-gurmukhi" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirogurmukhi",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirogurmukhi"
   name "Tiro Gurmukhi"
   desc "Reintroduces stroke modulation of traditional Punjabi manuscript"
   homepage "https://fonts.google.com/specimen/Tiro+Gurmukhi"

--- a/Casks/font-tiro-kannada.rb
+++ b/Casks/font-tiro-kannada.rb
@@ -2,9 +2,10 @@ cask "font-tiro-kannada" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirokannada",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirokannada"
   name "Tiro Kannada"
   desc "Especially suited to traditional literary publishing"
   homepage "https://fonts.google.com/specimen/Tiro+Kannada"

--- a/Casks/font-tiro-tamil.rb
+++ b/Casks/font-tiro-tamil.rb
@@ -2,9 +2,10 @@ cask "font-tiro-tamil" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirotamil",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirotamil"
   name "Tiro Tamil"
   desc "Especially suited to traditional literary publishing"
   homepage "https://fonts.google.com/specimen/Tiro+Tamil"

--- a/Casks/font-tiro-telugu.rb
+++ b/Casks/font-tiro-telugu.rb
@@ -2,9 +2,10 @@ cask "font-tiro-telugu" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tirotelugu",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tirotelugu"
   name "Tiro Telugu"
   desc "Especially suited to traditional literary publishing"
   homepage "https://fonts.google.com/specimen/Tiro+Telugu"

--- a/Casks/font-titillium-web.rb
+++ b/Casks/font-titillium-web.rb
@@ -2,9 +2,10 @@ cask "font-titillium-web" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/titilliumweb",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/titilliumweb"
   name "Titillium Web"
   homepage "https://fonts.google.com/specimen/Titillium+Web"
 

--- a/Casks/font-tomorrow.rb
+++ b/Casks/font-tomorrow.rb
@@ -2,9 +2,10 @@ cask "font-tomorrow" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tomorrow",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tomorrow"
   name "Tomorrow"
   homepage "https://fonts.google.com/specimen/Tomorrow"
 

--- a/Casks/font-tourney.rb
+++ b/Casks/font-tourney.rb
@@ -2,9 +2,10 @@ cask "font-tourney" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tourney",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tourney"
   name "Tourney"
   desc "Completely solid"
   homepage "https://fonts.google.com/specimen/Tourney"

--- a/Casks/font-trirong.rb
+++ b/Casks/font-trirong.rb
@@ -2,9 +2,10 @@ cask "font-trirong" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/trirong",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/trirong"
   name "Trirong"
   homepage "https://fonts.google.com/specimen/Trirong"
 

--- a/Casks/font-trochut.rb
+++ b/Casks/font-trochut.rb
@@ -2,9 +2,10 @@ cask "font-trochut" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/trochut",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/trochut"
   name "Trochut"
   homepage "https://fonts.google.com/specimen/Trochut"
 

--- a/Casks/font-tsukimi-rounded.rb
+++ b/Casks/font-tsukimi-rounded.rb
@@ -2,9 +2,10 @@ cask "font-tsukimi-rounded" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tsukimirounded",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tsukimirounded"
   name "Tsukimi Rounded"
   desc "Sans-serif typeface with rounded terminals"
   homepage "https://fonts.google.com/specimen/Tsukimi+Rounded"

--- a/Casks/font-tuffy.rb
+++ b/Casks/font-tuffy.rb
@@ -2,9 +2,10 @@ cask "font-tuffy" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/tuffy",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/tuffy"
   name "Tuffy"
   homepage "https://fonts.google.com/specimen/Tuffy"
 

--- a/Casks/font-turret-road.rb
+++ b/Casks/font-turret-road.rb
@@ -2,9 +2,10 @@ cask "font-turret-road" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/turretroad",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/turretroad"
   name "Turret Road"
   homepage "https://fonts.google.com/specimen/Turret+Road"
 

--- a/Casks/font-ubuntu-mono.rb
+++ b/Casks/font-ubuntu-mono.rb
@@ -2,9 +2,10 @@ cask "font-ubuntu-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ufl/ubuntumono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ufl/ubuntumono"
   name "Ubuntu Mono"
   homepage "https://fonts.google.com/specimen/Ubuntu+Mono"
 

--- a/Casks/font-ubuntu.rb
+++ b/Casks/font-ubuntu.rb
@@ -2,9 +2,10 @@ cask "font-ubuntu" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ufl/ubuntu",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ufl/ubuntu"
   name "Ubuntu"
   desc "Sans-serif typeface manually hinted for clarity"
   homepage "https://fonts.google.com/specimen/Ubuntu"

--- a/Casks/font-unkempt.rb
+++ b/Casks/font-unkempt.rb
@@ -2,9 +2,10 @@ cask "font-unkempt" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/apache/unkempt",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "apache/unkempt"
   name "Unkempt"
   homepage "https://fonts.google.com/specimen/Unkempt"
 

--- a/Casks/font-unna.rb
+++ b/Casks/font-unna.rb
@@ -2,9 +2,10 @@ cask "font-unna" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/unna",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/unna"
   name "Unna"
   homepage "https://fonts.google.com/specimen/Unna"
 

--- a/Casks/font-vesper-libre.rb
+++ b/Casks/font-vesper-libre.rb
@@ -2,9 +2,10 @@ cask "font-vesper-libre" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/vesperlibre",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/vesperlibre"
   name "Vesper Libre"
   homepage "https://fonts.google.com/specimen/Vesper+Libre"
 

--- a/Casks/font-volkhov.rb
+++ b/Casks/font-volkhov.rb
@@ -2,9 +2,10 @@ cask "font-volkhov" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/volkhov",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/volkhov"
   name "Volkhov"
   homepage "https://fonts.google.com/specimen/Volkhov"
 

--- a/Casks/font-vollkorn-sc.rb
+++ b/Casks/font-vollkorn-sc.rb
@@ -2,9 +2,10 @@ cask "font-vollkorn-sc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/vollkornsc",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/vollkornsc"
   name "Vollkorn SC"
   homepage "https://fonts.google.com/specimen/Vollkorn+SC"
 

--- a/Casks/font-windsong.rb
+++ b/Casks/font-windsong.rb
@@ -2,9 +2,10 @@ cask "font-windsong" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/windsong",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/windsong"
   name "WindSong"
   desc "Elongated script with multiple stylistic sets"
   homepage "https://fonts.google.com/specimen/WindSong"

--- a/Casks/font-xanh-mono.rb
+++ b/Casks/font-xanh-mono.rb
@@ -2,9 +2,10 @@ cask "font-xanh-mono" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/xanhmono",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/xanhmono"
   name "Xanh Mono"
   desc "Mono-serif typeface, designed by lam bao and duy dao"
   homepage "https://fonts.google.com/specimen/Xanh+Mono"

--- a/Casks/font-yaldevi-colombo.rb
+++ b/Casks/font-yaldevi-colombo.rb
@@ -2,9 +2,10 @@ cask "font-yaldevi-colombo" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/yaldevicolombo",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/yaldevicolombo"
   name "Yaldevi Colombo"
   homepage "https://fonts.google.com/specimen/Yaldevi+Colombo"
 

--- a/Casks/font-yantramanav.rb
+++ b/Casks/font-yantramanav.rb
@@ -2,9 +2,10 @@ cask "font-yantramanav" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/yantramanav",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/yantramanav"
   name "Yantramanav"
   homepage "https://fonts.google.com/specimen/Yantramanav"
 

--- a/Casks/font-yrsa.rb
+++ b/Casks/font-yrsa.rb
@@ -2,9 +2,10 @@ cask "font-yrsa" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/yrsa",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/yrsa"
   name "Yrsa"
   homepage "https://fonts.google.com/specimen/Yrsa"
 

--- a/Casks/font-zen-kaku-gothic-antique.rb
+++ b/Casks/font-zen-kaku-gothic-antique.rb
@@ -2,9 +2,10 @@ cask "font-zen-kaku-gothic-antique" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/zenkakugothicantique",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/zenkakugothicantique"
   name "Zen Kaku Gothic Antique"
   desc "Classical yet simple and stylish version"
   homepage "https://fonts.google.com/specimen/Zen+Kaku+Gothic+Antique"

--- a/Casks/font-zen-kaku-gothic-new.rb
+++ b/Casks/font-zen-kaku-gothic-new.rb
@@ -2,9 +2,10 @@ cask "font-zen-kaku-gothic-new" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/zenkakugothicnew",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/zenkakugothicnew"
   name "Zen Kaku Gothic New"
   desc "Classical yet simple and stylish version"
   homepage "https://fonts.google.com/specimen/Zen+Kaku+Gothic+New"

--- a/Casks/font-zen-loop.rb
+++ b/Casks/font-zen-loop.rb
@@ -2,9 +2,10 @@ cask "font-zen-loop" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/zenloop",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/zenloop"
   name "Zen Loop"
   desc "Latin fonts designed by yoshimichi ohira, as part of zen fonts collection"
   homepage "https://fonts.google.com/specimen/Zen+Loop"

--- a/Casks/font-zen-maru-gothic.rb
+++ b/Casks/font-zen-maru-gothic.rb
@@ -2,9 +2,10 @@ cask "font-zen-maru-gothic" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/zenmarugothic",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/zenmarugothic"
   name "Zen Maru Gothic"
   desc "Also easy to use in any scenes"
   homepage "https://fonts.google.com/specimen/Zen+Maru+Gothic"

--- a/Casks/font-zen-old-mincho.rb
+++ b/Casks/font-zen-old-mincho.rb
@@ -2,9 +2,10 @@ cask "font-zen-old-mincho" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/zenoldmincho",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/zenoldmincho"
   name "Zen Old Mincho"
   desc "Intended for text usage, it also works well in large sizes"
   homepage "https://fonts.google.com/specimen/Zen+Old+Mincho"

--- a/Casks/font-zilla-slab-highlight.rb
+++ b/Casks/font-zilla-slab-highlight.rb
@@ -2,9 +2,10 @@ cask "font-zilla-slab-highlight" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/google/fonts/trunk/ofl/zillaslabhighlight",
-      verified: "github.com/google/fonts/",
-      using:    :svn
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/zillaslabhighlight"
   name "Zilla Slab Highlight"
   homepage "https://fonts.google.com/specimen/Zilla+Slab+Highlight"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Follow-on PR from #5758 to flip the remaining Google fonts over from svn to git. Do not merge until 1) the success to brew 3.6.7 is released and 2) #5758 gets released a week or two have passed with no complaints from users.

It's a big change, so I haven't run `brew audit` on each cask. I have run `brew style` on each cask and they came out okay:

```
$ ls Casks | sed 's/\.rb//' | xargs brew style
Inspecting 1976 files
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

1976 files inspected, no offenses detected
```

To generate this change I wrote a simple autocorrecting Rubocop rule:

```ruby
module RuboCop
  module Cop
    module CustomCops
      class RewriteSvnToGit < Base
        extend AutoCorrector

        MSG = "Installing a Google font with SVN".freeze

        def on_send(node)
          receiver_node, method_name, *arg_nodes = *node
          return unless method_name == :url

          url = arg_nodes.grep(RuboCop::AST::StrNode)&.first
          opts = arg_nodes.grep(RuboCop::AST::HashNode)&.first
          return unless url && opts

          using_node = opts.pairs.select { |p| p.key.value == :using }.first
          return unless using_node && using_node&.value&.value == :svn
          return unless url.value.start_with?("https://github.com/google/fonts/trunk/")

          path = url.value.delete_prefix("https://github.com/google/fonts/trunk/")

          add_offense(using_node) do |corrector|
            corrector.replace(url, "\"https://github.com/google/fonts.git\"")

            opts_replacement = [
              'verified:  "github.com/google/fonts",',
              'branch:    "main",',
              "only_path: \"#{path}\"",
            ].join("\n      ")
            corrector.replace(opts, opts_replacement)
          end
        end
      end
    end
  end
end
```

Then ran it across all fonts with:

```console
$ rubocop --require ./svn_to_git.rb --only CustomCops/RewriteSvnToGit Casks --autocorrect
```

A couple of points to follow up on:
1. There are still some non-Google fonts that are hosted on GitHub and use svn – I should probably modify my Rubocop rule to handle them too.
2. If we're mass-migrating to git, the cache path will change for people who've already installed these fonts. Will the old caches ever get cleaned up?