### PR TITLE
Add desc and separate fonts on `Fira Code`

### DIFF
--- a/Casks/font-fira-code.rb
+++ b/Casks/font-fira-code.rb
@@ -4,10 +4,13 @@ cask "font-fira-code" do
 
   url "https://github.com/tonsky/FiraCode/releases/download/#{version}/Fira_Code_v#{version}.zip"
   name "Fira Code"
+  desc "Free monospaced font with programming ligatures."
   homepage "https://github.com/tonsky/FiraCode"
 
-  font "variable_ttf/FiraCode-VF.ttf"
-  # The FiraCode-Retina.tff font is not included in FiraCode-VF.ttf
-  # See https://github.com/Homebrew/homebrew-cask-fonts/issues/5396
+  font "ttf/FiraCode-Regular.ttf"
+  font "ttf/FiraCode-Light.ttf"
   font "ttf/FiraCode-Retina.ttf"
+  font "ttf/FiraCode-Medium.ttf"
+  font "ttf/FiraCode-SemiBold.ttf"
+  font "ttf/FiraCode-Bold.ttf"
 end

--- a/Casks/font-fira-code.rb
+++ b/Casks/font-fira-code.rb
@@ -4,13 +4,13 @@ cask "font-fira-code" do
 
   url "https://github.com/tonsky/FiraCode/releases/download/#{version}/Fira_Code_v#{version}.zip"
   name "Fira Code"
-  desc "Free monospaced font with programming ligatures."
+  desc "Free monospaced font with programming ligatures"
   homepage "https://github.com/tonsky/FiraCode"
 
-  font "ttf/FiraCode-Regular.ttf"
-  font "ttf/FiraCode-Light.ttf"
-  font "ttf/FiraCode-Retina.ttf"
-  font "ttf/FiraCode-Medium.ttf"
-  font "ttf/FiraCode-SemiBold.ttf"
   font "ttf/FiraCode-Bold.ttf"
+  font "ttf/FiraCode-Light.ttf"
+  font "ttf/FiraCode-Medium.ttf"
+  font "ttf/FiraCode-Regular.ttf"
+  font "ttf/FiraCode-Retina.ttf"
+  font "ttf/FiraCode-SemiBold.ttf"
 end


### PR DESCRIPTION
Separate fonts from `FiraCode-VF` to each weight fonts.
For editors or terminals, it becomes easy to specify which font weight to use by separating fonts.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
