### PR TITLE
font-mononoki: update sha256

### DIFF
--- a/Casks/font-mononoki.rb
+++ b/Casks/font-mononoki.rb
@@ -1,6 +1,6 @@
 cask "font-mononoki" do
   version "1.5"
-  sha256 "c5bc01793b506bcbbfaefbe0a7e49021511d19077d35db934303ecf454fb3c46"
+  sha256 "2159f39e133802f48f5a13863e63a3c66bcd316ff112ca74c23d7428007f9e6b"
 
   url "https://github.com/madmalik/mononoki/releases/download/#{version}/mononoki.zip",
       verified: "github.com/madmalik/mononoki/"


### PR DESCRIPTION
I updated the mononoki.zip for version 1.5 shorty after the release because there were some rendering issues, so the SHA hash changed. This is the correct hash of the re-released zip.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
