### PR TITLE
Update font-fira-mono-nerd-font from 2.2.1 to 2.2.2 (2)

### DIFF
--- a/Casks/font-fira-mono-nerd-font.rb
+++ b/Casks/font-fira-mono-nerd-font.rb
@@ -1,9 +1,9 @@
 cask "font-fira-mono-nerd-font" do
-  version "2.2.1"
-  sha256 "e60a9f8cd097c2cbaa54dc08dc861d6d02809cfc0d35d60410648cefb1855c23"
+  version "2.2.2"
+  sha256 "29fff85e0afe0bd723fbd84e6c9587b08fd277cacc516d49bd379faa95612ac3"
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/FiraMono.zip"
-  name "FiraMono Nerd Font (Fira)"
+  name "FuraMono Nerd Font (Fira)"
   desc "Developer targeted fonts with a high number of glyphs"
   homepage "https://github.com/ryanoasis/nerd-fonts"
 
@@ -12,10 +12,10 @@ cask "font-fira-mono-nerd-font" do
     strategy :github_latest
   end
 
-  font "Fira Mono Bold Nerd Font Complete.otf"
-  font "Fira Mono Medium Nerd Font Complete.otf"
-  font "Fira Mono Regular Nerd Font Complete.otf"
-  font "Fira Mono Bold Nerd Font Complete Mono.otf"
-  font "Fira Mono Medium Nerd Font Complete Mono.otf"
-  font "Fira Mono Regular Nerd Font Complete Mono.otf"
+  font "Fura Mono Bold Nerd Font Complete Mono.otf"
+  font "Fura Mono Bold Nerd Font Complete.otf"
+  font "Fura Mono Medium Nerd Font Complete Mono.otf"
+  font "Fura Mono Medium Nerd Font Complete.otf"
+  font "Fura Mono Regular Nerd Font Complete Mono.otf"
+  font "Fura Mono Regular Nerd Font Complete.otf"
 end


### PR DESCRIPTION
[why]
We want to be up to date, and the version 2.2.1 cask is broken.

[how]
Use Nerd Font's own generate-casks script.
This is a manual run (which is tricky).

[note]
Name in the description changed to the expected value. Once Nerd Fonts re-rename the font to Fira again, this will automatically follow.

Fixes: #6679
Obsoletes: #6681 

Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

### Notes

I have the feeling this might be somehow urgent, and I still struggle with some aspects of the complete automation of this process from Nerd Font's side. So I did use the script that I intend to use automatically to create these PRs, but did create the PR manually.

Unfortunately I can not tick the 2nd thing:
```
$ brew audit --cask --online font-fira-code-nerd-font.rb
[...]
Error: Invalid usage: Casks are not supported on Linux
```