### PR TITLE
Move remaining fonts from svn to git

### DIFF
--- a/Casks/font-anonymice-powerline.rb
+++ b/Casks/font-anonymice-powerline.rb
@@ -2,8 +2,9 @@ cask "font-anonymice-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/AnonymousPro",
-      using:      :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "AnonymousPro"
   name "Anonymice Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/AnonymousPro"
 

--- a/Casks/font-dejavu-sans-mono-for-powerline.rb
+++ b/Casks/font-dejavu-sans-mono-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-dejavu-sans-mono-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/DejaVuSansMono",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "DejaVuSansMono"
   name "DejaVu Sans Mono for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/DejaVuSansMono"
 

--- a/Casks/font-droid-sans-mono-for-powerline.rb
+++ b/Casks/font-droid-sans-mono-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-droid-sans-mono-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/DroidSansMono",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "DroidSansMono"
   name "Droid Sans Mono for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/DroidSansMono"
 

--- a/Casks/font-fira-mono-for-powerline.rb
+++ b/Casks/font-fira-mono-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-fira-mono-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/FiraMono",
-      using:      :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "FiraMono"
   name "Fira Mono for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/FiraMono"
 

--- a/Casks/font-inconsolata-g-for-powerline.rb
+++ b/Casks/font-inconsolata-g-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-inconsolata-g-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/Inconsolata-g",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "Inconsolata-g"
   name "Inconsolata-g for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/Inconsolata-g"
 

--- a/Casks/font-inconsolata-lgc.rb
+++ b/Casks/font-inconsolata-lgc.rb
@@ -2,8 +2,7 @@ cask "font-inconsolata-lgc" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/DeLaGuardo/Inconsolata-LGC/trunk",
-      using: :svn
+  url "https://github.com/DeLaGuardo/Inconsolata-LGC.git"
   name "Inconsolata LGC"
   homepage "https://github.com/DeLaGuardo/Inconsolata-LGC"
 

--- a/Casks/font-liberation-mono-for-powerline.rb
+++ b/Casks/font-liberation-mono-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-liberation-mono-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/LiberationMono",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "LiberationMono"
   name "Literation Mono for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/LiberationMono"
 

--- a/Casks/font-material-design-icons-webfont.rb
+++ b/Casks/font-material-design-icons-webfont.rb
@@ -2,10 +2,10 @@ cask "font-material-design-icons-webfont" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/templarian/materialdesign-webfont/trunk/fonts",
-      verified: "github.com/templarian/materialdesign-webfont/",
-      using:    :svn,
-      revision: "191"
+  url "https://github.com/templarian/materialdesign-webfont.git",
+      verified:  "github.com/templarian/materialdesign-webfont",
+      branch:    "master",
+      only_path: "fonts"
   name "Material Design Icons Webfont"
   homepage "https://materialdesignicons.com/"
 

--- a/Casks/font-monofur-for-powerline.rb
+++ b/Casks/font-monofur-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-monofur-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/Monofur",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "Monofur"
   name "monofur for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/Monofur"
 

--- a/Casks/font-noto-mono-for-powerline.rb
+++ b/Casks/font-noto-mono-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-noto-mono-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/NotoMono",
-      using:      :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "NotoMono"
   name "Noto Mono for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/NotoMono"
 

--- a/Casks/font-roboto-mono-for-powerline.rb
+++ b/Casks/font-roboto-mono-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-roboto-mono-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/RobotoMono",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "RobotoMono"
   name "Roboto Mono for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/RobotoMono"
 

--- a/Casks/font-source-code-pro-for-powerline.rb
+++ b/Casks/font-source-code-pro-for-powerline.rb
@@ -2,8 +2,9 @@ cask "font-source-code-pro-for-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/SourceCodePro",
-      using: :svn
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "SourceCodePro"
   name "Source Code Pro for Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/SourceCodePro"
 

--- a/Casks/font-ubuntu-mono-derivative-powerline.rb
+++ b/Casks/font-ubuntu-mono-derivative-powerline.rb
@@ -2,9 +2,9 @@ cask "font-ubuntu-mono-derivative-powerline" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/powerline/fonts/trunk/UbuntuMono",
-      using:    :svn,
-      revision: "53"
+  url "https://github.com/powerline/fonts.git",
+      branch:    "master",
+      only_path: "UbuntuMono"
   name "Ubuntu Mono derivative Powerline"
   homepage "https://github.com/powerline/fonts/tree/master/UbuntuMono"
 


### PR DESCRIPTION
Migrates the remaining `using: :svn` fonts to git, meaning svn is no longer a dependency for any fonts in this repo.

Follows on from https://github.com/Homebrew/homebrew-cask-fonts/pull/6507#issuecomment-1308843526.

Resolves https://github.com/Homebrew/brew/issues/11724.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
