### PR TITLE
Fix Cooper Hewitt download link

### DIFF
--- a/Casks/font-cooper-hewitt.rb
+++ b/Casks/font-cooper-hewitt.rb
@@ -2,8 +2,8 @@ cask "font-cooper-hewitt" do
   version :latest
   sha256 :no_check
 
-  url "https://uh8yh30l48rpize52xh0q1o6i-wpengine.netdna-ssl.com/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip",
-      verified: "uh8yh30l48rpize52xh0q1o6i-wpengine.netdna-ssl.com/wp-content/uploads/fonts/"
+  url "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip",
+      verified: "www.cooperhewitt.org/wp-content/uploads/fonts/"
   name "Cooper Hewitt"
   homepage "https://www.cooperhewitt.org/open-source-at-cooper-hewitt/cooper-hewitt-the-typeface-by-chester-jenkins/"
 

--- a/Casks/font-cooper-hewitt.rb
+++ b/Casks/font-cooper-hewitt.rb
@@ -4,6 +4,7 @@ cask "font-cooper-hewitt" do
 
   url "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip"
   name "Cooper Hewitt"
+  desc "Contemporary sans serif composed of modified-geometric curves and arches"
   homepage "https://www.cooperhewitt.org/open-source-at-cooper-hewitt/cooper-hewitt-the-typeface-by-chester-jenkins/"
 
   font "CooperHewitt-OTF-public/CooperHewitt-Bold.otf"

--- a/Casks/font-cooper-hewitt.rb
+++ b/Casks/font-cooper-hewitt.rb
@@ -2,8 +2,7 @@ cask "font-cooper-hewitt" do
   version :latest
   sha256 :no_check
 
-  url "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip",
-      verified: "www.cooperhewitt.org/wp-content/uploads/fonts/"
+  url "https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip"
   name "Cooper Hewitt"
   homepage "https://www.cooperhewitt.org/open-source-at-cooper-hewitt/cooper-hewitt-the-typeface-by-chester-jenkins/"
 


### PR DESCRIPTION
This PR fixes the URL for the Cooper Hewitt font, which seems to have been updated.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

<!-- Not a new cask, so N/A
Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
-->
