### PR TITLE
Update sha256 for font-lxgw-bright family.

### DIFF
--- a/Casks/font-lxgw-bright-gb.rb
+++ b/Casks/font-lxgw-bright-gb.rb
@@ -1,6 +1,6 @@
 cask "font-lxgw-bright-gb" do
   version "5.300"
-  sha256 "32ce152c995166ec05b7370f465855738edfff48a2f6c84f2b69a9566a6bb466"
+  sha256 "776ca05da16cd9ffc2b5f84747a83c86fbe448d3ed1f911c73e4a2c67370ae42"
 
   url "https://github.com/lxgw/LxgwBright/releases/download/v#{version}/LXGWBrightGB.7z"
   name "LXGW Bright GB"

--- a/Casks/font-lxgw-bright-tc.rb
+++ b/Casks/font-lxgw-bright-tc.rb
@@ -1,6 +1,6 @@
 cask "font-lxgw-bright-tc" do
   version "5.300"
-  sha256 "b9a273a5138a75101c1ddf5bfa4f7439b4f8a1bb5d4992acd239584cae8f46e6"
+  sha256 "bc43b2b8fa5a783b826fc1d6af5e086e7d48d73d914e0640af50ed5c4cfde1b4"
 
   url "https://github.com/lxgw/LxgwBright/releases/download/v#{version}/LXGWBrightTC.7z"
   name "LXGW Bright TC"

--- a/Casks/font-lxgw-bright.rb
+++ b/Casks/font-lxgw-bright.rb
@@ -1,6 +1,6 @@
 cask "font-lxgw-bright" do
   version "5.300"
-  sha256 "32d985558c404f75ad9436d9665d033812a857174bd96ba3c89d31f123805cc4"
+  sha256 "96882456311a1f4304bbe446002afed70f365985c2b4d238224c5baac1a3909b"
 
   url "https://github.com/lxgw/LxgwBright/releases/download/v#{version}/LXGWBright.7z"
   name "LXGW Bright"


### PR DESCRIPTION
Note: it seems the repo released the same version again with new file hashes. https://github.com/lxgw/LxgwBright/releases/tag/v5.300

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `bbrew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
