### PR TITLE
Update font-hackgen, font-hackgen-nerd from 2.8.0 to 2.9.0 

### DIFF
--- a/Casks/font-hackgen-nerd.rb
+++ b/Casks/font-hackgen-nerd.rb
@@ -1,6 +1,6 @@
 cask "font-hackgen-nerd" do
-  version "2.8.0"
-  sha256 "25cdd1487cc46df384d32c041303b4a04541fd61d0b973e8bb38fd1a3de65eb1"
+  version "2.9.0"
+  sha256 "277cb874bbcf8a884e512bb2a01d62341d57286d8947057d652fab6488fc941c"
 
   url "https://github.com/yuru7/HackGen/releases/download/v#{version}/HackGen_NF_v#{version}.zip"
   name "HackGenNerd"
@@ -9,10 +9,6 @@ cask "font-hackgen-nerd" do
 
   font "HackGen_NF_v#{version}/HackGen35ConsoleNF-Bold.ttf"
   font "HackGen_NF_v#{version}/HackGen35ConsoleNF-Regular.ttf"
-  font "HackGen_NF_v#{version}/HackGen35ConsoleNFJ-Bold.ttf"
-  font "HackGen_NF_v#{version}/HackGen35ConsoleNFJ-Regular.ttf"
   font "HackGen_NF_v#{version}/HackGenConsoleNF-Bold.ttf"
   font "HackGen_NF_v#{version}/HackGenConsoleNF-Regular.ttf"
-  font "HackGen_NF_v#{version}/HackGenConsoleNFJ-Bold.ttf"
-  font "HackGen_NF_v#{version}/HackGenConsoleNFJ-Regular.ttf"
 end

--- a/Casks/font-hackgen.rb
+++ b/Casks/font-hackgen.rb
@@ -1,6 +1,6 @@
 cask "font-hackgen" do
-  version "2.8.0"
-  sha256 "89ed3f0d8f6c3976a76594e659067a3fa57840a0cb44c601f8b36cc21f87b7c5"
+  version "2.9.0"
+  sha256 "123b2179866f5a291c15cf34a83fdce6ac202e2fe6ad27fbd9ddd4f5bff23c65"
 
   url "https://github.com/yuru7/HackGen/releases/download/v#{version}/HackGen_v#{version}.zip"
   name "HackGen"


### PR DESCRIPTION
Update version from `2.8.0` by this release, `https://github.com/yuru7/HackGen/releases/tag/v2.9.0`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
