### PR TITLE
Update Iosevka font family to 23.0.0.

### DIFF
--- a/Casks/font-iosevka-aile.rb
+++ b/Casks/font-iosevka-aile.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-aile" do
-  version "22.1.2"
-  sha256 "049b5e8903d262e31b3acfb13d6fdda9a40dfe431ff8def520d00319bc6f8330"
+  version "23.0.0"
+  sha256 "66074c0e162c86395b5f70fa90bf467364185e117d7d2acc3e858c8cbda26760"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-aile-#{version}.zip"
   name "Iosevka Aile"

--- a/Casks/font-iosevka-curly-slab.rb
+++ b/Casks/font-iosevka-curly-slab.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-curly-slab" do
-  version "22.1.2"
-  sha256 "740827999ea11442baf5a074def21d2c3aad800170a7406e5fb687b4015bbf7d"
+  version "23.0.0"
+  sha256 "39cf8d839c293e8066b1fc689f43f84316459f6fe4f0a0cfeb77ea2907fb2328"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-curly-slab-#{version}.zip"
   name "Iosevka Curly Slab"

--- a/Casks/font-iosevka-curly.rb
+++ b/Casks/font-iosevka-curly.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-curly" do
-  version "22.1.2"
-  sha256 "8adea14c58c829ab096e9ca0df9b92ce377829d7ab7036a7c13392db5442905a"
+  version "23.0.0"
+  sha256 "f827f6dace1fce90c357df9aa7be8b5038aeca2eba14da70224091ac00437ae9"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-curly-#{version}.zip"
   name "Iosevka Curly"

--- a/Casks/font-iosevka-etoile.rb
+++ b/Casks/font-iosevka-etoile.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-etoile" do
-  version "22.1.2"
-  sha256 "2e2dd18d5e5773b33aed12e81caa9d0413a7620dbb2775c7f9d299db8a3c1fb2"
+  version "23.0.0"
+  sha256 "dbbe61b7ee41ef21c9bd715a76b88f7c50c215d38d65033f79b6dc11a8519386"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-etoile-#{version}.zip"
   name "Iosevka Etoile"

--- a/Casks/font-iosevka-slab.rb
+++ b/Casks/font-iosevka-slab.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-slab" do
-  version "22.1.2"
-  sha256 "153a784d394717f67a273f94e27ae63d7e5011fea4967f2c049732dad793b4c2"
+  version "23.0.0"
+  sha256 "141591bc01c67d1faf5cda6a9caa07eac477cf83ab41a62d9b330ab79780169e"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-slab-#{version}.zip"
   name "Iosevka Slab"

--- a/Casks/font-iosevka-ss01.rb
+++ b/Casks/font-iosevka-ss01.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss01" do
-  version "22.1.2"
-  sha256 "ce94c8e06dc96c3f618f724dcb5f79e041609d19439edb930c670c8cf306d7c4"
+  version "23.0.0"
+  sha256 "eb274a0821e9554ed6f6c139aa2abc678c9c007b5ec220dc42d4e8208489e738"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss01-#{version}.zip"
   name "Iosevka SS01"

--- a/Casks/font-iosevka-ss02.rb
+++ b/Casks/font-iosevka-ss02.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss02" do
-  version "22.1.2"
-  sha256 "aa32f538593275bb958dcbe2a0b492c2ea3941f506713bbfae2ff4669340a829"
+  version "23.0.0"
+  sha256 "b50151181da9b0327ba737b98a550afe722443c8d5c00eccc9d118b4da9b9a96"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss02-#{version}.zip"
   name "Iosevka SS02"

--- a/Casks/font-iosevka-ss03.rb
+++ b/Casks/font-iosevka-ss03.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss03" do
-  version "22.1.2"
-  sha256 "1cc6a45e0069cb52337b1be3a078a37bff7182dbef05d309022e9e5e96ce3513"
+  version "23.0.0"
+  sha256 "58bbcba1affc429fed7d43d80bb946c371385fe78b61f9b3b4b7b9543d8941aa"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss03-#{version}.zip"
   name "Iosevka SS03"

--- a/Casks/font-iosevka-ss04.rb
+++ b/Casks/font-iosevka-ss04.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss04" do
-  version "22.1.2"
-  sha256 "ee1a395cdbbf0a9c1e01accaac2aa380949e5d818edd40a04bed4f2b0b3a1900"
+  version "23.0.0"
+  sha256 "75ff84a7c0db41f82633150429325db4facf576e9c2305cb7ba460e8c4999ede"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss04-#{version}.zip"
   name "Iosevka SS04"

--- a/Casks/font-iosevka-ss05.rb
+++ b/Casks/font-iosevka-ss05.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss05" do
-  version "22.1.2"
-  sha256 "956ebd8bd2aba4bc2cc01e21b75a3c2c356aec49547a9881590b00438db2d921"
+  version "23.0.0"
+  sha256 "a0faa385be375d42225132c9dc859b20602d56e851028d9053eb44f3ee2f8ce2"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss05-#{version}.zip"
   name "Iosevka SS05"

--- a/Casks/font-iosevka-ss06.rb
+++ b/Casks/font-iosevka-ss06.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss06" do
-  version "22.1.2"
-  sha256 "6eb552377ab30050b727be6ee6f28d4b174e39102e3414f22e58e0d117e0cb6d"
+  version "23.0.0"
+  sha256 "edc7240ad40ebcc31b5b6869b2070ec6b9b945c19a2cf155c7b161f61b0e418e"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss06-#{version}.zip"
   name "Iosevka SS06"

--- a/Casks/font-iosevka-ss07.rb
+++ b/Casks/font-iosevka-ss07.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss07" do
-  version "22.1.2"
-  sha256 "51088ef30fa3370456bdf00182801e4af03bfe9996e59eca82843adf169cdbf9"
+  version "23.0.0"
+  sha256 "58c053e87ee8d677e0bd6e6dc4e8fd3c9e2e471bacb14775e6a2b6e22ad5899e"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss07-#{version}.zip"
   name "Iosevka SS07"

--- a/Casks/font-iosevka-ss08.rb
+++ b/Casks/font-iosevka-ss08.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss08" do
-  version "22.1.2"
-  sha256 "21cdb0b1d42081977d736fbd2c682797d6e2d0f4ab37c9c6d094e46e1829ae2c"
+  version "23.0.0"
+  sha256 "6b2b46ceb4d101b086482138e2096bbb135e98615358729f74acaf32bdeaacfd"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss08-#{version}.zip"
   name "Iosevka SS08"

--- a/Casks/font-iosevka-ss09.rb
+++ b/Casks/font-iosevka-ss09.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss09" do
-  version "22.1.2"
-  sha256 "63616aee5f4d72e3d098495a5e0a86b5ac834a821065a9dd1e617bcf23e1d70e"
+  version "23.0.0"
+  sha256 "71477363b52986640221eadea2587fd4b5f0b3d4d94e7ae01f1f109ee9c67e19"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss09-#{version}.zip"
   name "Iosevka SS09"

--- a/Casks/font-iosevka-ss10.rb
+++ b/Casks/font-iosevka-ss10.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss10" do
-  version "22.1.2"
-  sha256 "e00cb36be9690f597ee28c35505dc0f007a670e4491982b2db9437053efb5fb8"
+  version "23.0.0"
+  sha256 "fb9dbffd491fbe754452bf76709377888a6b3d13f4662b58667931d8b29bb93a"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss10-#{version}.zip"
   name "Iosevka SS10"

--- a/Casks/font-iosevka-ss11.rb
+++ b/Casks/font-iosevka-ss11.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss11" do
-  version "22.1.2"
-  sha256 "93fb9590d19bed57b15a1b31a5f641778b7aa048becb8140ec535c11494f2e02"
+  version "23.0.0"
+  sha256 "96938d0d06e4c64fa18428052db228966919584fdb89fc1623cfd1967ea4780c"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss11-#{version}.zip"
   name "Iosevka SS11"

--- a/Casks/font-iosevka-ss12.rb
+++ b/Casks/font-iosevka-ss12.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss12" do
-  version "22.1.2"
-  sha256 "194f03f497ff3d67d1883ca53b4fa359cf7193285f2de6dec0612b5cb5c7da4a"
+  version "23.0.0"
+  sha256 "40474a3cc357b15bd65902d3e149f17918535502fe0c7152a5c52866d3257b2b"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss12-#{version}.zip"
   name "Iosevka SS12"

--- a/Casks/font-iosevka-ss13.rb
+++ b/Casks/font-iosevka-ss13.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss13" do
-  version "22.1.2"
-  sha256 "992875b10a634766795d7605306b2c82fcf7bc297cb2ca7c9893943093c1973b"
+  version "23.0.0"
+  sha256 "8dbd93836649c5d2ceb831d6938853d5ddf2af13a268315cc862baef6459924d"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss13-#{version}.zip"
   name "Iosevka SS13"

--- a/Casks/font-iosevka-ss14.rb
+++ b/Casks/font-iosevka-ss14.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss14" do
-  version "22.1.2"
-  sha256 "dfa1d76dbcd14f69e1a29615b999ccdea3383423fc80bad4f355a8dc716b000e"
+  version "23.0.0"
+  sha256 "6e6d6b4f098a1d8fa1c33ff83c3cab9a1f4df54a7b82a97aa75d04bcfe2be3c8"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss14-#{version}.zip"
   name "Iosevka SS14"

--- a/Casks/font-iosevka-ss15.rb
+++ b/Casks/font-iosevka-ss15.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss15" do
-  version "22.1.2"
-  sha256 "49861d0ddc4092320dcd7678d4dc63e3180248dc2b3e6d27bfc8c1f288f1e1a8"
+  version "23.0.0"
+  sha256 "52abe0f5a0a28e34d3e7e2dcab88ec3794d188bf640ed9008f32ef080ba0c94d"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss15-#{version}.zip"
   name "Iosevka SS15"

--- a/Casks/font-iosevka-ss16.rb
+++ b/Casks/font-iosevka-ss16.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss16" do
-  version "22.1.2"
-  sha256 "1894894873672de9d6a640662ff361f193c817d286ed06a0a824b96c8ec9717a"
+  version "23.0.0"
+  sha256 "6ea836d9ffbb32df3838d1c105f9e2c76ea3267e3da142876c915a835db5c628"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss16-#{version}.zip"
   name "Iosevka SS16"

--- a/Casks/font-iosevka-ss17.rb
+++ b/Casks/font-iosevka-ss17.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss17" do
-  version "22.1.2"
-  sha256 "74ad72ac68eae6102846786a4494eb7cf8b868ea27f890467929574131ee98d8"
+  version "23.0.0"
+  sha256 "b3943bd32ded6bdaa1a83fb42a843152b843303941412e136bcaf29c2c1b74a0"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss17-#{version}.zip"
   name "Iosevka SS17"

--- a/Casks/font-iosevka-ss18.rb
+++ b/Casks/font-iosevka-ss18.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka-ss18" do
-  version "22.1.2"
-  sha256 "4dee9dffaddf8d1a85b263a344d1ff250fb0d2f9994007d4520a2ae999900b66"
+  version "23.0.0"
+  sha256 "43d94d1abb3949d7a0aba30807ce7928cf49b051cd1918810d4ab1075ae23630"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-ss18-#{version}.zip"
   name "Iosevka SS18"

--- a/Casks/font-iosevka.rb
+++ b/Casks/font-iosevka.rb
@@ -1,6 +1,6 @@
 cask "font-iosevka" do
-  version "22.1.2"
-  sha256 "7879d21588b15bd1b854bb316f2a77f87c8e86d0c4c993e5ede656230a812e20"
+  version "23.0.0"
+  sha256 "9066f53d7960793ae14d941485d06170ebc484517317ad6ad1410b788e2cfa06"
 
   url "https://github.com/be5invis/Iosevka/releases/download/v#{version}/ttc-iosevka-#{version}.zip"
   name "Iosevka"


### PR DESCRIPTION
Changes were made with `brew bump-cask-pr --write-only` and committed together manually.

-------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
