### PR TITLE
cask_renames: rename font-source-sans-pro and font-source-serif-pro

### DIFF
--- a/cask_renames.json
+++ b/cask_renames.json
@@ -1,0 +1,4 @@
+{
+    "font-source-sans-pro": "font-source-sans-3",
+    "font-source-serif-pro": "font-source-serif-4"
+}


### PR DESCRIPTION
`font-source-sans-pro` and `font-source-sans-serif` were removed by the PR https://github.com/Homebrew/homebrew-cask-fonts/pull/7742 as they have been replaced upstream by variable font versions but were not removed from the `google/fonts` repo until https://github.com/google/fonts/pull/6328