### PR TITLE
font-sf-pro 19.0d6e1

### DIFF
--- a/Casks/font-sf-pro.rb
+++ b/Casks/font-sf-pro.rb
@@ -1,5 +1,5 @@
 cask "font-sf-pro" do
-  version "18.0d12e2"
+  version "19.0d6e1"
   sha256 :no_check
 
   url "https://devimages-cdn.apple.com/design/resources/download/SF-Pro.dmg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.