### PR TITLE
import_google_fonts: fallback to creator url when no google page present

### DIFF
--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -97,7 +97,7 @@ end
     def homepage(self):
         if self.homepage_override is not None:
           return self.homepage_override
-        
+
         if self.early_access:
             return f"https://fonts.google.com/earlyaccess"
 

--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -40,12 +40,12 @@ class FontCask:
 
 {% if files|length == 1 %}
   url "https://github.com/google/fonts/raw/main/{{folder}}/{{files[0] | urlencode}}"
-      {%- if not 'github.com/' in homepage %},
+      {%- if not 'github.com/google/fonts/' in homepage %},
       verified: "github.com/google/fonts/"
       {%- endif +%}
 {% else %}
   url "https://github.com/google/fonts.git",
-      {%- if not 'github.com/' in homepage +%}
+      {%- if not 'github.com/google/fonts/' in homepage +%}
       verified:  "github.com/google/fonts",
       {%- endif +%}
       branch:    "main",
@@ -97,7 +97,7 @@ end
     def homepage(self):
         if self.homepage_override is not None:
           return self.homepage_override
-
+        
         if self.early_access:
             return f"https://fonts.google.com/earlyaccess"
 
@@ -317,6 +317,12 @@ Download the or clone the repository from https://github.com/google/fonts, then 
 
           updated_casks[cask.token()] = cask
         else:
+          try:
+             urllib.request.urlopen(cask.homepage())
+          except urllib.request.URLError as e:
+            if e.code == 404:
+              cask.homepage_override = cask.meta.source.repository_url
+
           added_casks[cask.token()] = cask
 
     changed_casks = {}


### PR DESCRIPTION
This should resolve the issue where casks are created with non-existent homepages - https://github.com/Homebrew/homebrew-cask-fonts/pull/7874#issuecomment-1627558691
In cases where there is no page on the Google Fonts website we will fallback to the source repository.
The caveat here is that the source repository may at times be out of sync with the Google Fonts website.

CC: @miccal 

