### PR TITLE
fix(font-sarasa-gothic): correct sha256 for updated artifact for v0.41.3

### DIFF
--- a/Casks/font-sarasa-gothic.rb
+++ b/Casks/font-sarasa-gothic.rb
@@ -1,6 +1,6 @@
 cask "font-sarasa-gothic" do
   version "0.41.3"
-  sha256 "fd50bdce1582de326e2174367de97a9a82f3addb20b8f6b29607e463d1680a54"
+  sha256 "608bc9430de6ff5b2fb8ef6432b0cd42de3245f7f3bdebf95d7d1ac4da748d86"
 
   url "https://github.com/be5invis/Sarasa-Gothic/releases/download/v#{version}/sarasa-gothic-ttc-#{version}.7z"
   name "Sarasa Gothic"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

It seems that the assets was re-uploaded 3 days ago with a different sha256
![image](https://github.com/Homebrew/homebrew-cask-fonts/assets/2211542/1b5230f7-38c1-4e63-99d2-a203c06683c3)
