### PR TITLE
Remove outdated SVN reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 homebrew-cask-fonts will only accept fonts which are freely-distributable. However, even freely-distributable fonts may have limitations (for instance, if you use them in a commercial enterprise). It is the responsibility of the user to know and respect the license of each font.
 
-## Installation behind a proxy
-
-Some font Casks use [Subversion](https://subversion.apache.org/), which requires [configuration when behind a proxy](https://subversion.apache.org/faq.html#proxy).
-
 ## homebrew-cask-fonts License
 
 Code is under the [BSD 2 Clause (NetBSD) license](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/LICENSE)


### PR DESCRIPTION
The SVN section in the README (added with https://github.com/Homebrew/homebrew-cask-fonts/pull/2424) is no longer relevant since all the fonts have been migrated to Git (see https://github.com/Homebrew/homebrew-cask-fonts/pull/6725).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
