### PR TITLE
Add font-intone-mono-nerd-font.rb v3.0.2

### DIFF
--- a/Casks/font-intone-mono-nerd-font.rb
+++ b/Casks/font-intone-mono-nerd-font.rb
@@ -1,0 +1,41 @@
+cask "font-intone-mono-nerd-font" do
+  version "3.0.2"
+  sha256 "cd2d6e9e37e3b76fe4563c64df79cc91e81b7c264faaf1b7599087810659830b"
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/IntelOneMono.zip"
+  name "IntoneMono Nerd Font (Intel One Mono)"
+  desc "Developer targeted fonts with a high number of glyphs"
+  homepage "https://github.com/ryanoasis/nerd-fonts"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "IntoneMonoNerdFont-Bold.ttf"
+  font "IntoneMonoNerdFont-BoldItalic.ttf"
+  font "IntoneMonoNerdFont-Italic.ttf"
+  font "IntoneMonoNerdFont-Light.ttf"
+  font "IntoneMonoNerdFont-LightItalic.ttf"
+  font "IntoneMonoNerdFont-Medium.ttf"
+  font "IntoneMonoNerdFont-MediumItalic.ttf"
+  font "IntoneMonoNerdFont-Regular.ttf"
+  font "IntoneMonoNerdFontMono-Bold.ttf"
+  font "IntoneMonoNerdFontMono-BoldItalic.ttf"
+  font "IntoneMonoNerdFontMono-Italic.ttf"
+  font "IntoneMonoNerdFontMono-Light.ttf"
+  font "IntoneMonoNerdFontMono-LightItalic.ttf"
+  font "IntoneMonoNerdFontMono-Medium.ttf"
+  font "IntoneMonoNerdFontMono-MediumItalic.ttf"
+  font "IntoneMonoNerdFontMono-Regular.ttf"
+  font "IntoneMonoNerdFontPropo-Bold.ttf"
+  font "IntoneMonoNerdFontPropo-BoldItalic.ttf"
+  font "IntoneMonoNerdFontPropo-Italic.ttf"
+  font "IntoneMonoNerdFontPropo-Light.ttf"
+  font "IntoneMonoNerdFontPropo-LightItalic.ttf"
+  font "IntoneMonoNerdFontPropo-Medium.ttf"
+  font "IntoneMonoNerdFontPropo-MediumItalic.ttf"
+  font "IntoneMonoNerdFontPropo-Regular.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
### This is the `Intel One Mono` version patched by Nerd Fonts.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Any `brew audit` fails with `Error: Calling brew audit [path ...] is disabled!` ?!
I'm too stupid to fix that.