### PR TITLE
Use https links for TeX Gyre

### DIFF
--- a/Casks/font-tex-gyre-adventor.rb
+++ b/Casks/font-tex-gyre-adventor.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-adventor" do
   name "TeX Gyre Adventor"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Adventor</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "qag#{version.dots_to_underscores}otf/texgyreadventor-bold.otf"
   font "qag#{version.dots_to_underscores}otf/texgyreadventor-bolditalic.otf"
   font "qag#{version.dots_to_underscores}otf/texgyreadventor-italic.otf"

--- a/Casks/font-tex-gyre-adventor.rb
+++ b/Casks/font-tex-gyre-adventor.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-adventor" do
   version "2.501"
   sha256 "9e619eb1c8af5cb55240f8bb865453562a2efd9059dee39d085fb71f7a00f7a2"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor/qag#{version.dots_to_underscores}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor/qag#{version.dots_to_underscores}otf.zip"
   name "TeX Gyre Adventor"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/adventor"
 
   font "qag#{version.dots_to_underscores}otf/texgyreadventor-bold.otf"
   font "qag#{version.dots_to_underscores}otf/texgyreadventor-bolditalic.otf"

--- a/Casks/font-tex-gyre-bonum-math.rb
+++ b/Casks/font-tex-gyre-bonum-math.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-bonum-math" do
   name "Bonum Math"
   homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tg-math/download"
+    regex(/Bonum\sMath\s\(OTF\),\sversion\s(\d+(?:\.\d+)+)/i)
+  end
+
   font "texgyrebonum-math-#{version.no_dots}/opentype/texgyrebonum-math.otf"
 
   # No zap stanza required

--- a/Casks/font-tex-gyre-bonum-math.rb
+++ b/Casks/font-tex-gyre-bonum-math.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-bonum-math" do
   version "1.005"
   sha256 "8f8dc6f52ff838201f581f20b4ab634508e6d4b1e2745fe5d6b7732e1df73290"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyrebonum-math-#{version.no_dots}.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyrebonum-math-#{version.no_dots}.zip"
   name "Bonum Math"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tg-math"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
   font "texgyrebonum-math-#{version.no_dots}/opentype/texgyrebonum-math.otf"
 

--- a/Casks/font-tex-gyre-bonum.rb
+++ b/Casks/font-tex-gyre-bonum.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-bonum" do
   version "2.004"
   sha256 "30e7e9bf24b73709edff9916c95214a66b7fac38f78a11a19e4bc18ab019d398"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/bonum/qbk#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/bonum/qbk#{version}otf.zip"
   name "TeX Gyre Bonum"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/bonum"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/bonum"
 
   font "texgyrebonum-bold.otf"
   font "texgyrebonum-bolditalic.otf"

--- a/Casks/font-tex-gyre-bonum.rb
+++ b/Casks/font-tex-gyre-bonum.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-bonum" do
   name "TeX Gyre Bonum"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/bonum"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Bonum</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "texgyrebonum-bold.otf"
   font "texgyrebonum-bolditalic.otf"
   font "texgyrebonum-italic.otf"

--- a/Casks/font-tex-gyre-chorus.rb
+++ b/Casks/font-tex-gyre-chorus.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-chorus" do
   name "TeX Gyre Chorus"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/chorus"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Chorus</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "texgyrechorus-mediumitalic.otf"
 
   # No zap stanza required

--- a/Casks/font-tex-gyre-chorus.rb
+++ b/Casks/font-tex-gyre-chorus.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-chorus" do
   version "2.003"
   sha256 "fbd905a504e6f86df9c38b42c6ed58681a10e6debae6afa6308bc031695cdbd8"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/chorus/qzc#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/chorus/qzc#{version}otf.zip"
   name "TeX Gyre Chorus"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/chorus"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/chorus"
 
   font "texgyrechorus-mediumitalic.otf"
 

--- a/Casks/font-tex-gyre-cursor.rb
+++ b/Casks/font-tex-gyre-cursor.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-cursor" do
   name "TeX Gyre Cursor"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/cursor"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Cursor</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "texgyrecursor-bold.otf"
   font "texgyrecursor-bolditalic.otf"
   font "texgyrecursor-italic.otf"

--- a/Casks/font-tex-gyre-cursor.rb
+++ b/Casks/font-tex-gyre-cursor.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-cursor" do
   version "2.004"
   sha256 "ae8db1c134ec5c1b8c3999116b0610a5ad1c6f47520c3b4712b9bc914458dce9"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/cursor/qcr#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/cursor/qcr#{version}otf.zip"
   name "TeX Gyre Cursor"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/cursor"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/cursor"
 
   font "texgyrecursor-bold.otf"
   font "texgyrecursor-bolditalic.otf"

--- a/Casks/font-tex-gyre-heros.rb
+++ b/Casks/font-tex-gyre-heros.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-heros" do
   name "TeX Gyre Heros"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/heros"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Heros</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "texgyreheros-bold.otf"
   font "texgyreheros-bolditalic.otf"
   font "texgyreheros-italic.otf"

--- a/Casks/font-tex-gyre-heros.rb
+++ b/Casks/font-tex-gyre-heros.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-heros" do
   version "2.004"
   sha256 "755954b7349b803fc1c3d82fe9d9c4f7cf66467af718eaaf4f78ae1a09bf265d"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/heros/qhv#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/heros/qhv#{version}otf.zip"
   name "TeX Gyre Heros"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/heros"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/heros"
 
   font "texgyreheros-bold.otf"
   font "texgyreheros-bolditalic.otf"

--- a/Casks/font-tex-gyre-pagella-math.rb
+++ b/Casks/font-tex-gyre-pagella-math.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-pagella-math" do
   name "Pagella Math"
   homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tg-math/download"
+    regex(/Pagella\sMath\s\(OTF\),\sversion\s(\d+(?:\.\d+)+)/i)
+  end
+
   font "texgyrepagella-math-#{version.no_dots}/opentype/texgyrepagella-math.otf"
 
   # No zap stanza required

--- a/Casks/font-tex-gyre-pagella-math.rb
+++ b/Casks/font-tex-gyre-pagella-math.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-pagella-math" do
   version "1.632"
   sha256 "68a9c0ce195915334673960b13a281f24d31a8ae380454a0e35652dba506d474"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyrepagella-math-#{version.no_dots}.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyrepagella-math-#{version.no_dots}.zip"
   name "Pagella Math"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tg-math"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
   font "texgyrepagella-math-#{version.no_dots}/opentype/texgyrepagella-math.otf"
 

--- a/Casks/font-tex-gyre-pagella.rb
+++ b/Casks/font-tex-gyre-pagella.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-pagella" do
   name "TeX Gyre Pagella"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Pagella</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "qpl#{version.dots_to_underscores}otf/texgyrepagella-bold.otf"
   font "qpl#{version.dots_to_underscores}otf/texgyrepagella-bolditalic.otf"
   font "qpl#{version.dots_to_underscores}otf/texgyrepagella-italic.otf"

--- a/Casks/font-tex-gyre-pagella.rb
+++ b/Casks/font-tex-gyre-pagella.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-pagella" do
   version "2.501"
   sha256 "e16078d19860d68a54bcaedc00e35c2a81b396cdc36842700f1d556f89cf8ef2"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella/qpl#{version.dots_to_underscores}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella/qpl#{version.dots_to_underscores}otf.zip"
   name "TeX Gyre Pagella"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/pagella"
 
   font "qpl#{version.dots_to_underscores}otf/texgyrepagella-bold.otf"
   font "qpl#{version.dots_to_underscores}otf/texgyrepagella-bolditalic.otf"

--- a/Casks/font-tex-gyre-schola-math.rb
+++ b/Casks/font-tex-gyre-schola-math.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-schola-math" do
   name "Schola Math"
   homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tg-math/download"
+    regex(/Schola\sMath\s\(OTF\),\sversion\s(\d+(?:\.\d+)+)/i)
+  end
+
   font "texgyreschola-math-1533/opentype/texgyreschola-math.otf"
 
   # No zap stanza required

--- a/Casks/font-tex-gyre-schola-math.rb
+++ b/Casks/font-tex-gyre-schola-math.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-schola-math" do
   version "1.533"
   sha256 "53560861144138e25f89f1f487126d21c81c5086364ffcf2c8e5e46e37ebbe00"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyreschola-math-#{version.no_dots}.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyreschola-math-#{version.no_dots}.zip"
   name "Schola Math"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tg-math"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
   font "texgyreschola-math-1533/opentype/texgyreschola-math.otf"
 

--- a/Casks/font-tex-gyre-schola.rb
+++ b/Casks/font-tex-gyre-schola.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-schola" do
   name "TeX Gyre Schola"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/schola"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Schola</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "texgyreschola-bold.otf"
   font "texgyreschola-bolditalic.otf"
   font "texgyreschola-italic.otf"

--- a/Casks/font-tex-gyre-schola.rb
+++ b/Casks/font-tex-gyre-schola.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-schola" do
   version "2.005"
   sha256 "24063368bfdc1046439e290299157621a437294ecbb39a938d2ddb2afa3daaf8"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/schola/qcs#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/schola/qcs#{version}otf.zip"
   name "TeX Gyre Schola"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/schola"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/schola"
 
   font "texgyreschola-bold.otf"
   font "texgyreschola-bolditalic.otf"

--- a/Casks/font-tex-gyre-termes-math.rb
+++ b/Casks/font-tex-gyre-termes-math.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-termes-math" do
   name "Termes Math"
   homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tg-math/download"
+    regex(/Termes\sMath\s\(OTF\),\sversion\s(\d+(?:\.\d+)+)/i)
+  end
+
   font "texgyretermes-math-1543/opentype/texgyretermes-math.otf"
 
   # No zap stanza required

--- a/Casks/font-tex-gyre-termes-math.rb
+++ b/Casks/font-tex-gyre-termes-math.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-termes-math" do
   version "1.543"
   sha256 "5875b39d3987cbe4258e5933a2292fbece870177053c5a8f495492769e2d4bb2"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyretermes-math-#{version.no_dots}.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyretermes-math-#{version.no_dots}.zip"
   name "Termes Math"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tg-math"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tg-math"
 
   font "texgyretermes-math-1543/opentype/texgyretermes-math.otf"
 

--- a/Casks/font-tex-gyre-termes.rb
+++ b/Casks/font-tex-gyre-termes.rb
@@ -2,9 +2,9 @@ cask "font-tex-gyre-termes" do
   version "2.004"
   sha256 "5d467d8db17c96037b04409d682f071d7cc33cf94eda35a0a0465776a2c862b2"
 
-  url "http://www.gust.org.pl/projects/e-foundry/tex-gyre/termes/qtm#{version}otf.zip"
+  url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/termes/qtm#{version}otf.zip"
   name "TeX Gyre Termes"
-  homepage "http://www.gust.org.pl/projects/e-foundry/tex-gyre/termes"
+  homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/termes"
 
   font "texgyretermes-bold.otf"
   font "texgyretermes-bolditalic.otf"

--- a/Casks/font-tex-gyre-termes.rb
+++ b/Casks/font-tex-gyre-termes.rb
@@ -6,6 +6,11 @@ cask "font-tex-gyre-termes" do
   name "TeX Gyre Termes"
   homepage "https://www.gust.org.pl/projects/e-foundry/tex-gyre/termes"
 
+  livecheck do
+    url "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole"
+    regex(%r{Termes</a>,\sver\.\s(\d+(?:\.\d+)+)}i)
+  end
+
   font "texgyretermes-bold.otf"
   font "texgyretermes-bolditalic.otf"
   font "texgyretermes-italic.otf"


### PR DESCRIPTION
The http links now 404:

```
03:54:09 ❯ curl -v  http://www.gust.org.pl/projects/e-foundry/tex-gyre/bonum/qbk2.004otf.zip
*   Trying 158.75.62.7:80...
* Connected to www.gust.org.pl (158.75.62.7) port 80 (#0)
> GET /projects/e-foundry/tex-gyre/bonum/qbk2.004otf.zip HTTP/1.1
> Host: www.gust.org.pl
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Server: nginx
< Date: Sat, 29 Jul 2023 22:24:42 GMT
< Content-Type: text/html
< Content-Length: 146
< Connection: keep-alive
<
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
* Connection #0 to host www.gust.org.pl left intact
```

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

