### PR TITLE
Update font-commit-mono.rb

### DIFF
--- a/Casks/font-commit-mono.rb
+++ b/Casks/font-commit-mono.rb
@@ -8,10 +8,10 @@ cask "font-commit-mono" do
   desc "Neutral programming typeface"
   homepage "https://commitmono.com/"
 
-  font "CommitMono-450-Italic.otf"
-  font "CommitMono-450-Regular.otf"
-  font "CommitMono-700-Italic.otf"
-  font "CommitMono-700-Regular.otf"
+  font "src/fonts/export/CommitMono-450-Italic.otf"
+  font "src/fonts/export/CommitMono-450-Regular.otf"
+  font "src/fonts/export/CommitMono-700-Italic.otf"
+  font "src/fonts/export/CommitMono-700-Regular.otf"
 
   # No zap stanza required
 end

--- a/Casks/font-commit-mono.rb
+++ b/Casks/font-commit-mono.rb
@@ -1,6 +1,6 @@
 cask "font-commit-mono" do
   version "1.136"
-  sha256 "1c31a67b5e2d1124574cfdc88d18c2f8222a060e55fb85243fcf2d4a1bb4c68a"
+  sha256 "4b7334d69c2a0d71a707d3ff52048123ce06aa076746961a968becd1f4dc883a"
 
   url "https://github.com/eigilnikolajsen/commit-mono/releases/download/#{version}/CommitMono-#{version}.zip",
       verified: "github.com/eigilnikolajsen/commit-mono/"


### PR DESCRIPTION
For whatever reason, the release artifact for this version of Commit Mono changed. This updates the hash.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I have to figure out how to run those last 2 checks there — I've never updated a cask before. I'll work on that and check them off when they're done.