### PR TITLE
update source of noto-emoji

### DIFF
--- a/Casks/font-noto-emoji.rb
+++ b/Casks/font-noto-emoji.rb
@@ -2,12 +2,12 @@ cask "font-noto-emoji" do
   version :latest
   sha256 :no_check
 
-  url "https://noto-website-2.storage.googleapis.com/pkgs/NotoEmoji-unhinted.zip",
-      verified: "noto-website-2.storage.googleapis.com/"
+  url "https://github.com/google/fonts/raw/main/ofl/notoemoji/NotoEmoji%5Bwght%5D.ttf",
+      verified: "github.com/google/fonts/"
   name "Noto Emoji"
-  homepage "https://www.google.com/get/noto/#emoji-zsye"
+  homepage "https://fonts.google.com/noto/specimen/Noto+Emoji"
 
-  font "NotoEmoji-Regular.ttf"
+  font "NotoEmoji[wght].ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
Updates the source of noto-emoji. Considerations: development of noto-emoji (the b/w version) was paused until recently (see source repo's [readme]). The updated version has more glyphs and does resemble noto-color-emoji while deprecating the blob-head style. This cask still serves the outdated version.

[readme]: https://github.com/googlefonts/noto-emoji#monochrome-font

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
