### PR TITLE
font-geist-mono: remove conflicting font

### DIFF
--- a/Casks/font-geist-mono.rb
+++ b/Casks/font-geist-mono.rb
@@ -22,7 +22,6 @@ cask "font-geist-mono" do
   font "Geist Mono/GeistMono-Thin.otf"
   font "Geist Mono/GeistMono-UltraBlack.otf"
   font "Geist Mono/GeistMono-UltraLight.otf"
-  font "Geist Mono/GeistMonoVF.ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
Font casks should preference the variable font option over static fonts where possible, however the variable font for Geist Mono currently has issues.