### PR TITLE
No Oblique version of Victor Mono

### DIFF
--- a/Casks/font-victor-mono-no-oblique.rb
+++ b/Casks/font-victor-mono-no-oblique.rb
@@ -1,0 +1,30 @@
+cask "font-victor-mono-no-oblique" do
+  version "1.5.5"
+  sha256 :no_check
+
+  url "https://rubjo.github.io/victor-mono/VictorMonoAll.zip"
+  name "Victor Mono (no oblique)"
+  desc "Monospaced font with cursive italics and programming symbol ligatures, oblique variants removed"
+  homepage "https://rubjo.github.io/victor-mono/"
+
+  livecheck do
+    url "https://github.com/rubjo/victor-mono/releases"
+  end
+
+  font "OTF/VictorMono-Thin.otf"
+  font "OTF/VictorMono-ExtraLight.otf"
+  font "OTF/VictorMono-Light.otf"
+  font "OTF/VictorMono-Regular.otf"
+  font "OTF/VictorMono-Medium.otf"
+  font "OTF/VictorMono-SemiBold.otf"
+  font "OTF/VictorMono-Bold.otf"
+  font "OTF/VictorMono-ThinItalic.otf"
+  font "OTF/VictorMono-ExtraLightItalic.otf"
+  font "OTF/VictorMono-LightItalic.otf"
+  font "OTF/VictorMono-Italic.otf"
+  font "OTF/VictorMono-MediumItalic.otf"
+  font "OTF/VictorMono-SemiBoldItalic.otf"
+  font "OTF/VictorMono-BoldItalic.otf"
+
+  # No zap stanza required
+end

--- a/Casks/font-victor-mono-no-oblique.rb
+++ b/Casks/font-victor-mono-no-oblique.rb
@@ -4,7 +4,7 @@ cask "font-victor-mono-no-oblique" do
 
   url "https://rubjo.github.io/victor-mono/VictorMonoAll.zip"
   name "Victor Mono (no oblique)"
-  desc "Monospaced font with cursive italics and programming symbol ligatures, oblique variants removed"
+  desc "Monospaced font with cursive italics and programming symbol ligatures"
   homepage "https://rubjo.github.io/victor-mono/"
 
   livecheck do


### PR DESCRIPTION
This helps with issues where certain IDEs (Jetbrains) use Oblique variants over Italics due to a bug.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
