### PR TITLE
font-material-symbols: re-add and skip in automated script

### DIFF
--- a/Casks/font-material-symbols.rb
+++ b/Casks/font-material-symbols.rb
@@ -1,0 +1,18 @@
+cask "font-material-symbols" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/google/material-design-icons.git",
+      verified:  "github.com/google/material-design-icons",
+      branch:    "master",
+      only_path: "variablefont"
+  name "Material Symbols"
+  desc "Icons based on Material Design principles as variable fonts"
+  homepage "https://fonts.google.com/icons"
+
+  font "MaterialSymbolsOutlined[FILL,GRAD,opsz,wght].ttf"
+  font "MaterialSymbolsRounded[FILL,GRAD,opsz,wght].ttf"
+  font "MaterialSymbolsSharp[FILL,GRAD,opsz,wght].ttf"
+
+  # No zap stanza required
+end

--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -194,6 +194,10 @@ def find_google_casks():
     with open(cask_path, "r") as f:
       contents = f.read()
 
+      # Skip "font-material-symbols" as it matches the url regex, but is not included in the Google Fonts repo
+      if os.path.basename(cask_path) == "font-material-symbols.rb":
+        continue
+
       if not re.search(r"(github\.com\/google\/fonts|fonts\.google\.com|google\.com/fonts)", contents):
         continue
 


### PR DESCRIPTION
This PR re-adds `font-material-symbols` after it was removed in #8680.

The automated script detects this as a "Google Font" although it is distributed separately.
Added a manual skip to the script, because the repository matches the regex for finding Google Fonts.