### PR TITLE
Fixed URLs for fonts and changed to TTF

### DIFF
--- a/Casks/font-ia-writer-duospace.rb
+++ b/Casks/font-ia-writer-duospace.rb
@@ -6,10 +6,12 @@ cask "font-ia-writer-duospace" do
   name "iA Writer Duospace"
   homepage "https://github.com/iaolo/iA-Fonts"
 
-  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-Bold.ttf"
-  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-BoldItalic.ttf"
-  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-Regular.ttf"
-  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-Italic.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuoS-Bold.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuoS-BoldItalic.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuoS-Italic.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuoS-Regular.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Variable/iAWriterDuoV-Italic.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Variable/iAWriterDuoV.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font-ia-writer-duospace.rb
+++ b/Casks/font-ia-writer-duospace.rb
@@ -6,10 +6,10 @@ cask "font-ia-writer-duospace" do
   name "iA Writer Duospace"
   homepage "https://github.com/iaolo/iA-Fonts"
 
-  font "iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-Bold.otf"
-  font "iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-BoldItalic.otf"
-  font "iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-Regular.otf"
-  font "iA-Fonts-master/iA Writer Duospace/OTF (Mac)/iAWriterDuospace-Italic.otf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-Bold.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-BoldItalic.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-Regular.ttf"
+  font "iA-Fonts-master/iA Writer Duo/Static/iAWriterDuospace-Italic.ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
The content and the structure of the repository has changed. There are no OTF fonts supplied, and the directory structure is different.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
