### PR TITLE
font-noto-serif-cjk 2.002

### DIFF
--- a/Casks/font-noto-serif-cjk.rb
+++ b/Casks/font-noto-serif-cjk.rb
@@ -8,7 +8,7 @@ cask "font-noto-serif-cjk" do
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^Serif(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/font-noto-serif-cjk.rb
+++ b/Casks/font-noto-serif-cjk.rb
@@ -1,11 +1,16 @@
 cask "font-noto-serif-cjk" do
-  version :latest
-  sha256 :no_check
+  version "2.002"
+  sha256 "e78b23ea9f803d8376eee66d330a556e1133b713ff97014a75991d5723324f85"
 
-  url "https://noto-website-2.storage.googleapis.com/pkgs/NotoSerifCJK.ttc.zip",
-      verified: "noto-website-2.storage.googleapis.com/"
+  url "https://github.com/notofonts/noto-cjk/releases/download/Serif#{version}/01_NotoSerifCJK.ttc.zip"
   name "Noto Serif CJK"
-  homepage "https://www.google.com/get/noto/help/cjk/"
+  desc "Static Super OTC"
+  homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
+
+  livecheck do
+    url :stable
+    regex(/^Serif(\d+(?:\.\d+)+)$/i)
+  end
 
   font "NotoSerifCJK.ttc"
 


### PR DESCRIPTION
**Why need an update**

The old url https://noto-website-2.storage.googleapis.com/pkgs/NotoSerifCJK.ttc.zip provides an outdated version 1.001, packed back in 2017. While the latest version is 2.002, see https://github.com/notofonts/noto-cjk/releases/tag/Serif2.002.

**Why updated in this way**

https://fonts.google.com only provides variable ttf font file in Noto Serif CJK bundle for each language, for example `NotoSerifSC[wght].ttf` and its corresponding cask [`font-noto-serif-sc.rb`](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-noto-serif-sc.rb) for Noto Serif CJK SC (Simplified Chinese). But this cask provides a static super ttc font file, which is only available from releases of repository https://github.com/notofonts/noto-cjk.

**Remark**

More casks need to be updated in this way, including symmetric Noto Sans CJK cask [`font-noto-sans-cjk.rb`](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-noto-sans-cjk.rb) and language specific Serif and Sans casks like [`font-noto-sans-cjk-sc.rb`](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-noto-sans-cjk-sc.rb).

I started with only one cask to check I did everything right.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
