### PR TITLE
font-noto-sans-cjk 2.004

### DIFF
--- a/Casks/font-noto-sans-cjk.rb
+++ b/Casks/font-noto-sans-cjk.rb
@@ -1,11 +1,16 @@
 cask "font-noto-sans-cjk" do
-  version :latest
-  sha256 :no_check
+  version "2.004"
+  sha256 "a56077736038875f3a5b1e6715b2713a2bd049cc0bf0dfdf645927b070d38bfc"
 
-  url "https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJK.ttc.zip",
-      verified: "noto-website-2.storage.googleapis.com/"
+  url "https://github.com/notofonts/noto-cjk/releases/download/Sans#{version}/00_NotoSansCJK.ttc.zip"
   name "Noto Sans CJK"
-  homepage "https://www.google.com/get/noto/help/cjk/"
+  desc "Static Super OTC"
+  homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
+
+  livecheck do
+    url :url
+    regex(/^Sans(\d+(?:\.\d+)+)$/i)
+  end
 
   font "NotoSansCJK.ttc"
 

--- a/Casks/font-noto-sans-cjk.rb
+++ b/Casks/font-noto-sans-cjk.rb
@@ -9,7 +9,8 @@ cask "font-noto-sans-cjk" do
 
   livecheck do
     url :url
-    regex(/^Sans(\d+(?:\.\d+)+)$/i)
+    regex(/^(?:Noto)?Sans[._-]?v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   font "NotoSansCJK.ttc"


### PR DESCRIPTION
Symmetric PR of #8720.

The language specific casks for Noto Sans CJK are a bit different than their Serif correspondings, hence will be updated in a separate PR.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
