### PR TITLE
Use `deprecate!` instead of `discontinued`

### DIFF
--- a/Casks/font-amiri.rb
+++ b/Casks/font-amiri.rb
@@ -8,16 +8,14 @@ cask "font-amiri" do
   desc "Classical Arabic typeface in Naskh style"
   homepage "https://www.amirifont.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   font "Amiri-#{version}/Amiri-Bold.ttf"
   font "Amiri-#{version}/Amiri-BoldItalic.ttf"
   font "Amiri-#{version}/Amiri-Italic.ttf"
   font "Amiri-#{version}/Amiri-Regular.ttf"
   font "Amiri-#{version}/AmiriQuran.ttf"
   font "Amiri-#{version}/AmiriQuranColored.ttf"
-
-  caveats do
-    discontinued
-  end
 
   # No zap stanza required
 end

--- a/Casks/font-clear-sans.rb
+++ b/Casks/font-clear-sans.rb
@@ -9,6 +9,8 @@ cask "font-clear-sans" do
   desc "Sans-serif typeface"
   homepage "https://github.com/intel/clear-sans"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   font "ClearSans-Bold.ttf"
   font "ClearSans-BoldItalic.ttf"
   font "ClearSans-Italic.ttf"
@@ -19,8 +21,4 @@ cask "font-clear-sans" do
   font "ClearSans-Thin.ttf"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/font-xits.rb
+++ b/Casks/font-xits.rb
@@ -7,16 +7,14 @@ cask "font-xits" do
   desc "Times-like typeface for mathematical and scientific publishing"
   homepage "https://github.com/khaledhosny/xits"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   font "xits-#{version}/xits-bold.otf"
   font "xits-#{version}/xits-bolditalic.otf"
   font "xits-#{version}/xits-italic.otf"
   font "xits-#{version}/xits-regular.otf"
   font "xits-#{version}/xitsmath-bold.otf"
   font "xits-#{version}/xitsmath-regular.otf"
-
-  caveats do
-    discontinued
-  end
 
   # No zap stanza required
 end


### PR DESCRIPTION
See https://github.com/Homebrew/brew/pull/16292

Move all instances of `discontinued` in the `caveats` stanza to a `deprecate!` call.

For now, I've left the date for all of these as today (`2023-12-17`) because it doesn't seem to me like it will be a good use of my time to go through each and figure out an appropriate date. If that isn't the best solution, though, I'm happy to hear about alternatives.

This PR was made using `brew style --fix` with https://github.com/Homebrew/brew/pull/16351 checked out, and then the non-autocorrectable (when the `caveats` stanza includes more than just `discontinued`) offenses were handled manually.

Note: this PR cannot be merged until a new Homebrew/brew tag (4.2.0) is made.
