### PR TITLE
developer/bin/font_casker: disable `Style/TopLevelMethodDefinition` rubocop

### DIFF
--- a/developer/bin/font_casker
+++ b/developer/bin/font_casker
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Style/TopLevelMethodDefinition
+
 #
 # font_casker
 #
@@ -200,3 +202,5 @@ if ARGV.length != 1
 end
 
 puts cask
+
+# rubocop:enable Style/TopLevelMethodDefinition


### PR DESCRIPTION
A new Rubocop was enabled in this PR, https://github.com/Homebrew/brew/pull/16538
Which is causing some errors in internal scripts, disabling the rubocop on the individual files to unblock CI.