### PR TITLE
font-glow-sans-*: deprecate

### DIFF
--- a/Casks/font-glow-sans-j-compressed.rb
+++ b/Casks/font-glow-sans-j-compressed.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-j-compressed" do
   name "Glow Sans J Compressed"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansJ-Compressed-Bold.otf"
   font "GlowSansJ-Compressed-Book.otf"
   font "GlowSansJ-Compressed-ExtraBold.otf"

--- a/Casks/font-glow-sans-j-condensed.rb
+++ b/Casks/font-glow-sans-j-condensed.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-j-condensed" do
   name "Glow Sans J Condensed"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansJ-Condensed-Bold.otf"
   font "GlowSansJ-Condensed-Book.otf"
   font "GlowSansJ-Condensed-ExtraBold.otf"

--- a/Casks/font-glow-sans-j-extended.rb
+++ b/Casks/font-glow-sans-j-extended.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-j-extended" do
   name "Glow Sans J Extended"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansJ-Extended-Bold.otf"
   font "GlowSansJ-Extended-Book.otf"
   font "GlowSansJ-Extended-ExtraBold.otf"

--- a/Casks/font-glow-sans-j-normal.rb
+++ b/Casks/font-glow-sans-j-normal.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-j-normal" do
   name "Glow Sans J Normal"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansJ-Normal-Bold.otf"
   font "GlowSansJ-Normal-Book.otf"
   font "GlowSansJ-Normal-ExtraBold.otf"

--- a/Casks/font-glow-sans-j-wide.rb
+++ b/Casks/font-glow-sans-j-wide.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-j-wide" do
   name "Glow Sans J Wide"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansJ-Wide-Bold.otf"
   font "GlowSansJ-Wide-Book.otf"
   font "GlowSansJ-Wide-ExtraBold.otf"

--- a/Casks/font-glow-sans-sc-compressed.rb
+++ b/Casks/font-glow-sans-sc-compressed.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-sc-compressed" do
   name "Glow Sans SC Compressed"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansSC-Compressed-Bold.otf"
   font "GlowSansSC-Compressed-Book.otf"
   font "GlowSansSC-Compressed-ExtraBold.otf"

--- a/Casks/font-glow-sans-sc-condensed.rb
+++ b/Casks/font-glow-sans-sc-condensed.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-sc-condensed" do
   name "Glow Sans SC Condensed"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansSC-Condensed-Bold.otf"
   font "GlowSansSC-Condensed-Book.otf"
   font "GlowSansSC-Condensed-ExtraBold.otf"

--- a/Casks/font-glow-sans-sc-extended.rb
+++ b/Casks/font-glow-sans-sc-extended.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-sc-extended" do
   name "Glow Sans SC Extended"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansSC-Extended-Bold.otf"
   font "GlowSansSC-Extended-Book.otf"
   font "GlowSansSC-Extended-ExtraBold.otf"

--- a/Casks/font-glow-sans-sc-normal.rb
+++ b/Casks/font-glow-sans-sc-normal.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-sc-normal" do
   name "Glow Sans SC Normal"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansSC-Normal-Bold.otf"
   font "GlowSansSC-Normal-Book.otf"
   font "GlowSansSC-Normal-ExtraBold.otf"

--- a/Casks/font-glow-sans-sc-wide.rb
+++ b/Casks/font-glow-sans-sc-wide.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-sc-wide" do
   name "Glow Sans SC Wide"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansSC-Wide-Bold.otf"
   font "GlowSansSC-Wide-Book.otf"
   font "GlowSansSC-Wide-ExtraBold.otf"

--- a/Casks/font-glow-sans-tc-compressed.rb
+++ b/Casks/font-glow-sans-tc-compressed.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-tc-compressed" do
   name "Glow Sans TC Compressed"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansTC-Compressed-Bold.otf"
   font "GlowSansTC-Compressed-Book.otf"
   font "GlowSansTC-Compressed-ExtraBold.otf"

--- a/Casks/font-glow-sans-tc-condensed.rb
+++ b/Casks/font-glow-sans-tc-condensed.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-tc-condensed" do
   name "Glow Sans TC Condensed"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansTC-Condensed-Bold.otf"
   font "GlowSansTC-Condensed-Book.otf"
   font "GlowSansTC-Condensed-ExtraBold.otf"

--- a/Casks/font-glow-sans-tc-extended.rb
+++ b/Casks/font-glow-sans-tc-extended.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-tc-extended" do
   name "Glow Sans TC Extended"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansTC-Extended-Bold.otf"
   font "GlowSansTC-Extended-Book.otf"
   font "GlowSansTC-Extended-ExtraBold.otf"

--- a/Casks/font-glow-sans-tc-normal.rb
+++ b/Casks/font-glow-sans-tc-normal.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-tc-normal" do
   name "Glow Sans TC Normal"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansTC-Normal-Bold.otf"
   font "GlowSansTC-Normal-Book.otf"
   font "GlowSansTC-Normal-ExtraBold.otf"

--- a/Casks/font-glow-sans-tc-wide.rb
+++ b/Casks/font-glow-sans-tc-wide.rb
@@ -6,6 +6,8 @@ cask "font-glow-sans-tc-wide" do
   name "Glow Sans TC Wide"
   homepage "https://github.com/welai/glow-sans"
 
+  deprecate! date: "2024-02-17", because: :discontinued
+
   font "GlowSansTC-Wide-Bold.otf"
   font "GlowSansTC-Wide-Book.otf"
   font "GlowSansTC-Wide-ExtraBold.otf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for the `glow-sans` fonts](https://github.com/welai/glow-sans) was archived on 2023-07-27. The most recent release (v0.93) was on 2021-09-09 and the most recent commit was on 2022-03-11. The `README` wasn't updated to explain the project status before the repository was archived but this seems to suggest that it isn't being developed/maintained further. This PR deprecates the related casks accordingly.