### PR TITLE
font-lxgw-zhenkai: deprecate

### DIFF
--- a/Casks/font-lxgw-zhenkai.rb
+++ b/Casks/font-lxgw-zhenkai.rb
@@ -8,6 +8,8 @@ cask "font-lxgw-zhenkai" do
   desc "Bolder-weight Edition of LXGW WenKai"
   homepage "https://github.com/lxgw/LxgwZhenKai"
 
+  deprecate! date: "2024-02-18", because: :discontinued
+
   font "LXGWZhenKai.ttf"
 
   # No zap stanza required


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `lxgw-zhenkai`](https://github.com/lxgw/LxgwZhenKai) was archived on 2022-08-04. The most recent release (v0.600) was on 2022-05-07 and the most recent commit was on 2022-07-19. The [`README` was updated on 2022-06-07](https://github.com/lxgw/LxgwZhenKai/commit/96193b7f2fb96bbc3d356ab25aa8b29c42d9f6f5) to contain a message saying that the font will no longer be updated:

> 本字体不再更新

This PR deprecates the cask accordingly.