### PR TITLE
font-linux-libertine: update version, livecheck

### DIFF
--- a/Casks/font-linux-biolinum.rb
+++ b/Casks/font-linux-biolinum.rb
@@ -1,15 +1,24 @@
 cask "font-linux-biolinum" do
-  version "5.3.0_2012_07_02"
+  version "5.3.0,2012_07_02"
   sha256 "24a593a949808d976850131a953c0c0d7a72299531dfbb348191964cc038d75d"
 
-  url "https://downloads.sourceforge.net/linuxlibertine/LinLibertineTTF_#{version}.tgz",
+  url "https://downloads.sourceforge.net/linuxlibertine/LinLibertineTTF_#{version.tr(",", "_")}.tgz",
       verified: "downloads.sourceforge.net/linuxlibertine/"
   name "Linux Biolinum"
+  desc "Libre multilingual sans-serif font"
   homepage "http://linuxlibertine.org/"
 
+  # The regex below specifically matches filenames with a version and optional
+  # date. One release (5.0.0) only used a date, so that will be treated as the
+  # newest version until it's no longer in the RSS feed.
   livecheck do
-    url "https://sourceforge.net/projects/linuxlibertine/rss"
-    regex(%r{/LinLibertineTTF_(\d+(?:\.\d+)+_(?:\d+(?:_\d+)+))\.})
+    url "https://sourceforge.net/projects/linuxlibertine/rss?path=/linuxlibertine"
+    regex(%r{url=.*?/LinLibertine(?:Font|TTF)[._-]v?(\d+(?:[.-]\d+)+)(?:[_-](\d+(?:[_-]\d+)+))?\.}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
+    end
   end
 
   font "LinBiolinum_Kah.ttf"

--- a/Casks/font-linux-libertine.rb
+++ b/Casks/font-linux-libertine.rb
@@ -1,15 +1,24 @@
 cask "font-linux-libertine" do
-  version "5.3.0_2012_07_02"
+  version "5.3.0,2012_07_02"
   sha256 "24a593a949808d976850131a953c0c0d7a72299531dfbb348191964cc038d75d"
 
-  url "https://downloads.sourceforge.net/linuxlibertine/LinLibertineTTF_#{version}.tgz",
+  url "https://downloads.sourceforge.net/linuxlibertine/LinLibertineTTF_#{version.tr(",", "_")}.tgz",
       verified: "downloads.sourceforge.net/linuxlibertine/"
   name "Linux Libertine"
+  desc "Libre multilingual serif font"
   homepage "http://linuxlibertine.org/"
 
+  # The regex below specifically matches filenames with a version and optional
+  # date. One release (5.0.0) only used a date, so that will be treated as the
+  # newest version until it's no longer in the RSS feed.
   livecheck do
-    url "https://sourceforge.net/projects/linuxlibertine/rss"
-    regex(%r{/LinLibertineTTF_(\d+(?:\.\d+)+_(?:\d+(?:_\d+)+))\.})
+    url "https://sourceforge.net/projects/linuxlibertine/rss?path=/linuxlibertine"
+    regex(%r{url=.*?/LinLibertine(?:Font|TTF)[._-]v?(\d+(?:[.-]\d+)+)(?:[_-](\d+(?:[_-]\d+)+))?\.}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
+    end
   end
 
   font "LinLibertine_DRah.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `livecheck` block for `font-linux-libertine` and `font-linux-biolinum` uses a SourceForge RSS feed URL that's the same as the default URL from the `Sourceforge` strategy. In the process of addressing this redundancy, I tested whether the `livecheck` block was required and saw that it's necessary because the 5.0.0 release tarball only uses a date, so `2011_05_22` would erroneously be returned as newest. Looking through releases, there are some with only a version (e.g., 4.4.1), some with a version that has a numeric suffix (e.g., 4.7.5-2), some with a version and date (e.g., 5.3.0_2012_07_02), and the aforementioned one with only a date.

The `font-linux-biolinum` and `font-linux-libertine` casks both use a `5.3.0_2012_07_02` version. This is what's used in the tarball file name but the upstream [version directories](https://sourceforge.net/projects/linuxlibertine/files/linuxlibertine/) are like `1.2.3` or `1.2.3-4`. Considering this along with the variety of version formats above, I think it makes sense to use a CSV version format like `5.3.0,2012_07_02` instead (along with `version.tr(",", "_")` in the `url`).

This PR updates the `version`/`url` and the `livecheck` block for these casks accordingly.