### PR TITLE
Update Sourceforge livecheck blocks

### DIFF
--- a/Casks/font-computer-modern.rb
+++ b/Casks/font-computer-modern.rb
@@ -5,11 +5,12 @@ cask "font-computer-modern" do
   url "https://downloads.sourceforge.net/cm-unicode/cm-unicode-#{version}-ttf.tar.xz",
       verified: "downloads.sourceforge.net/cm-unicode/"
   name "Computer Modern"
+  desc "Multilingual unicode fonts, mainly for X applications"
   homepage "https://cm-unicode.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/cm-unicode/rss"
-    regex(%r{/cm-unicode/(\d+(?:\.\d+)*)})
+    url "https://sourceforge.net/projects/cm-unicode/rss?path=/cm-unicode"
+    regex(%r{url=.*?/cm-unicode/v?(\d+(?:\.\d+)+[a-z]?)/})
   end
 
   font "cm-unicode-#{version}/cmunbbx.ttf"

--- a/Casks/font-dejavu.rb
+++ b/Casks/font-dejavu.rb
@@ -7,8 +7,7 @@ cask "font-dejavu" do
   homepage "https://sourceforge.net/projects/dejavu/"
 
   livecheck do
-    url "https://sourceforge.net/projects/dejavu/rss"
-    regex(%r{/dejavu/(\d+(?:\.\d+)*)})
+    url "https://sourceforge.net/projects/dejavu/rss?path=/dejavu"
   end
 
   font "dejavu-fonts-ttf-#{version}/ttf/DejaVuMathTeXGyre.ttf"

--- a/Casks/font-han-nom-a.rb
+++ b/Casks/font-han-nom-a.rb
@@ -7,8 +7,8 @@ cask "font-han-nom-a" do
   homepage "https://sourceforge.net/projects/vietunicode/files/hannom/hannom%20v2005/"
 
   livecheck do
-    url "https://sourceforge.net/projects/vietunicode/rss"
-    regex(%r{/hannom v(\d+)})
+    url "https://sourceforge.net/projects/vietunicode/rss?path=/hannom"
+    regex(%r{url=.*?/hannom(?:\s|%20)*v?(\d+(?:\.\d+)*)/}i)
   end
 
   font "HAN NOM A.ttf"

--- a/Casks/font-junicode.rb
+++ b/Casks/font-junicode.rb
@@ -8,8 +8,11 @@ cask "font-junicode" do
   homepage "https://junicode.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/junicode/rss"
-    regex(/junicode-(\d+(?:\.\d+)*)/)
+    url "https://sourceforge.net/projects/junicode/rss?path=/junicode"
+    regex(%r{url=.*?/junicode[._-]v?(\d+(?:[.-]\d+)+)\.(?:t|zip)}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
+    end
   end
 
   font "FoulisGreek.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The casks in this PR contain a `livecheck` block where the specified `url` string is the same as the default URL generated by livecheck's `Sourceforge` strategy (i.e., they're redundant). This updates the URLs to avoid this redundancy. In this case, I've added a `path` query string parameter to each, to restrict the RSS feed to the directory we're interested in.

This PR also:

* Updates the `regex` for `font-computer-modern`, `font-han-nom-a`, and `font-junicode` to improve them and bring them more in line with typical `Sourceforge` regexes.
* Adds a `strategy` block for `junicode`, to convert the older `0-7-8` version format in file names to `0.7.8.
* Removes the `regex` from `font-dejavu`, as the default from the `Sourceforge` strategy accomplishes the same thing. [We could technically use something like `regex(%r{url=.*?/dejavu-fonts-ttf[._-]v?(\d+(?:\.\d+)+)\.}i)` if we strictly want to match `dejavu-fonts-ttf` files but that could quietly fail to match a new version if they change the file name format. Granted, it would also match a version that doesn't include the file we need but that doesn't seem to be an issue based on past versions.]

Edit: I added a `desc` for `font-computer-modern` but feel free to update it.