### PR TITLE
font-sarasa-gothic: fix source url

### DIFF
--- a/Casks/font-sarasa-gothic.rb
+++ b/Casks/font-sarasa-gothic.rb
@@ -1,8 +1,8 @@
 cask "font-sarasa-gothic" do
   version "1.0.6"
-  sha256 "ce842295201de41a4b09b4f153405aba975cd5553110dbcd11cf69845545528a"
+  sha256 "f8787a8d9092d69e0d7c35bcc7c3590496d5180019f31ce848b906dc6b659564"
 
-  url "https://github.com/be5invis/Sarasa-Gothic/releases/download/v#{version}/Sarasa-TTC-#{version}.7z"
+  url "https://github.com/be5invis/Sarasa-Gothic/releases/download/v#{version}b/Sarasa-SuperTTC-#{version}.zip"
   name "Sarasa Gothic"
   name "更纱黑体"
   name "更紗黑體"
@@ -11,16 +11,11 @@ cask "font-sarasa-gothic" do
   desc "CJK programming font based on Iosevka and Source Han Sans"
   homepage "https://github.com/be5invis/Sarasa-Gothic"
 
-  font "Sarasa-Bold.ttc"
-  font "Sarasa-BoldItalic.ttc"
-  font "Sarasa-ExtraLight.ttc"
-  font "Sarasa-ExtraLightItalic.ttc"
-  font "Sarasa-Italic.ttc"
-  font "Sarasa-Light.ttc"
-  font "Sarasa-LightItalic.ttc"
-  font "Sarasa-Regular.ttc"
-  font "Sarasa-SemiBold.ttc"
-  font "Sarasa-SemiBoldItalic.ttc"
+  livecheck do
+    regex(/(\d+(?:\.\d+)+)/)
+  end
+
+  font "Sarasa-SuperTTC.ttc"
 
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

`font-sarasa-gothic` republished [1.0.6](https://github.com/be5invis/Sarasa-Gothic/releases/tag/v1.0.6b) with different URL.
fix be5invis/Sarasa-Gothic#371.