### PR TITLE
Add font-hermit.rb

### DIFF
--- a/Casks/font-hermit.rb
+++ b/Casks/font-hermit.rb
@@ -1,0 +1,18 @@
+cask "font-hermit" do
+  version "2.0"
+  sha256 "c04b432b088edabc8ff025049535077722869f842fb6f851864106b7f4f03527"
+
+  url "https://pcaro.es/d/otf-hermit-#{version}.tar.gz"
+  name "Hermit"
+  desc "A monospace font designed to be clear, pragmatic and very readable"
+  homepage "https://pcaro.es/p/hermit/"
+
+  font "Hermit-Bold.otf"
+  font "Hermit-RegularItalic.otf"
+  font "Hermit-LightItalic.otf"
+  font "Hermit-Light.otf"
+  font "Hermit-Regular.otf"
+  font "Hermit-BoldItalic.otf"
+
+  # No zap stanza required
+end

--- a/Casks/font-hermit.rb
+++ b/Casks/font-hermit.rb
@@ -4,8 +4,13 @@ cask "font-hermit" do
 
   url "https://pcaro.es/d/otf-hermit-#{version}.tar.gz"
   name "Hermit"
-  desc "A monospace font designed to be clear, pragmatic and very readable"
+  desc "Monospace font designed to be clear, pragmatic and very readable"
   homepage "https://pcaro.es/p/hermit/"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?hermit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   font "Hermit-Bold.otf"
   font "Hermit-RegularItalic.otf"


### PR DESCRIPTION
Re-create #1974 with a newer version (1.21 -> 2.0).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

```
Error: Cask 'font-hermit' is unavailable: No Cask with this name exists.
```

- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=Issues).

It was: #1974. The previous version was broken.

- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.

```
% brew audit --cask --new font-hermit
Error: Cask 'font-hermit' is unavailable: No Cask with this name exists.
```

- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
