### PR TITLE
Fix: change location of genshin-gothic to IIJ

### DIFF
--- a/Casks/font-genshingothic.rb
+++ b/Casks/font-genshingothic.rb
@@ -2,7 +2,7 @@ cask "font-genshingothic" do
   version "20150607,8.637"
   sha256 "b8e00f00a6e2517bfe75ceb2a732b596fe002457b89c05c181d6b71373aada58"
 
-  url "https://osdn.dl.osdn.jp/users/#{version.csv.second.major}/#{version.csv.second.no_dots}/genshingothic-#{version.csv.first}.zip",
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/users/#{version.csv.second.major}/#{version.csv.second.no_dots}/genshingothic-#{version.csv.first}.zip",
       verified: "osdn.jp/"
   name "Gen Shin Gothic"
   homepage "http://jikasei.me/font/genshin/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Now genshin-gothic zip archive is hosted on IIJ.