### PR TITLE
Add new cascadia with nerd fonts created on version v2404.23

### DIFF
--- a/Casks/font-cascadia-code-nf.rb
+++ b/Casks/font-cascadia-code-nf.rb
@@ -1,0 +1,19 @@
+cask "font-cascadia-code-nf" do
+  version "2404.23"
+  sha256 "a911410626c0e09d03fa3fdda827188fda96607df50fecc3c5fee5906e33251b"
+
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
+  name "Cascadia Code NF"
+  desc "Version of Cascadia Code with embedded Nerd Fonts symbols"
+  homepage "https://github.com/microsoft/cascadia-code"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "ttf/CascadiaCodeNF.ttf"
+  font "ttf/CascadiaCodeNFItalic.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font-cascadia-mono-nf.rb
+++ b/Casks/font-cascadia-mono-nf.rb
@@ -1,0 +1,19 @@
+cask "font-cascadia-mono-nf" do
+  version "2404.23"
+  sha256 "a911410626c0e09d03fa3fdda827188fda96607df50fecc3c5fee5906e33251b"
+
+  url "https://github.com/microsoft/cascadia-code/releases/download/v#{version}/CascadiaCode-#{version}.zip"
+  name "Cascadia Mono NF"
+  desc "Version of Cascadia Code without ligatures and with embedded Nerd Fonts symbols"
+  homepage "https://github.com/microsoft/cascadia-code"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  font "ttf/CascadiaMonoNF.ttf"
+  font "ttf/CascadiaMonoNFItalic.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
