### PR TITLE
Bump Monaspace font version to v1.100

### DIFF
--- a/Casks/font-monaspace.rb
+++ b/Casks/font-monaspace.rb
@@ -1,6 +1,6 @@
 cask "font-monaspace" do
-  version "1.000"
-  sha256 "3e08376fd0aeca1f851fde0c08e18ca2d797f6a4c7a449670bf4d1270303c8f6"
+  version "1.100"
+  sha256 "6cdd653e3f6708585f563c86b1e19a63a02dc95b46d1c8924dc19e55d834967e"
 
   url "https://github.com/githubnext/monaspace/releases/download/v#{version}/monaspace-v#{version}.zip",
       verified: "github.com/githubnext/monaspace/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
Let me know if there are any problems. Unless they removed/added/renamed any specific files in the `fonts/otf/` directory, meaning specific styles and weights, everything should work fine.