### PR TITLE
Document installation via Brewfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ $ brew tap homebrew/cask-fonts         # You only need to do this once!
 $ brew install font-inconsolata
 ```
 
+Or in a [brew-bundle](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
+
+```ruby
+tap "homebrew/cask-fonts"
+cask "font-inconsolata"
+```
+
 ## Submitting a Cask to this repository
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Font installation has changed a few times (particularly from caskroom tap) and googling for how to install fonts via Brewfile surfaces a few conflicting approaches.

I think it would be beneficial if taps documented how they were to be used within a Brewfile. This is especially helpful for homebrew's first-party taps, to remove any potential confusion that there may perhaps be a `font "inconsolata"` mechanism or similar; given that `brew`, `cask`, `mas`, `whalebrew` and `vscode` are all first-class Brewfile methods. It also eliminates any confusion about whether the `font-` prefix should be present in the Brewfile, given that there are other prefixes in the homebrew ecosystem that can conventionally be omitted in certain cases. Thus, an explicit example seems worthwhile.


---
_(not a cask PR, so the following is not applicable)_

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
