### PR TITLE
fix font-wix-madefor-text

### DIFF
--- a/Casks/font-wix-madefor-text.rb
+++ b/Casks/font-wix-madefor-text.rb
@@ -1,16 +1,14 @@
 cask "font-wix-madefor-text" do
-  version :latest
-  sha256 :no_check
+  version "3.100"
+  sha256 "7fdbd012ca9e245d7c177a341bdbdf789521590e175322a9013c035981138f1c"
 
-  url "https://github.com/google/fonts.git",
-      verified:  "github.com/google/fonts",
-      branch:    "main",
-      only_path: "ofl/wixmadefortext"
+  url "https://github.com/wix-incubator/wixmadefor/releases/download/#{version}/wixmadefor-fonts.zip",
+      verified: "github.com/wix-incubator/wixmadefor/"
   name "Wix Madefor Text"
   homepage "https://fonts.google.com/specimen/Wix+Madefor+Text"
 
-  font "WixMadeforText[wght].ttf"
-  font "WixMadeforText-Italic[wght].ttf"
+  font "wixmadefor-fonts/fonts/variable/WixMadeforText[wght].ttf"
+  font "wixmadefor-fonts/fonts/variable/WixMadeforText-Italic[wght].ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
changed the url to the upstream repo one and added the sha256 checksum

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask-fonts/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Changed the url according to #9398 